### PR TITLE
Fix `org-checkbox' and `org-agenda-date-today'

### DIFF
--- a/solarized-theme.el
+++ b/solarized-theme.el
@@ -358,6 +358,19 @@
      `(org-todo ((,class (:bold t :foreground ,red :weight bold))))
      `(org-upcoming-deadline ((,class (:inherit font-lock-keyword-face))))
      `(org-warning ((,class (:bold t :foreground ,red :weight bold))))
+     ;; org-habit
+     `(org-habit-clear-face ((,class ,(if (eq variant 'light)
+                                       `(:foreground ,base02 :background "#bbbbff")
+                                       `(:foreground ,base01 :background "blue")))))
+     `(org-habit-clear-future-face ((,class (:foreground ,(if (eq variant 'light) base02 base00)))))
+     `(org-habit-ready-face ((,class ,(if (eq variant 'light)
+                                        `(:foreground ,base02 :background "#aaffbb")
+                                        `(:foreground ,base02 :background "forestgreen")))))
+     `(org-habit-ready-future-face ((,class (:foreground ,base01))))
+     `(org-habit-alert-face ((,class (:foreground ,base01))))
+     `(org-habit-alert-future-face ((,class (:foreground ,base02))))
+     `(org-habit-overdue-face ((,class (:foreground ,base01))))
+     `(org-habit-overdue-future-face ((,class (:foreground ,base01))))
 
      ;; outline
      `(outline-8 ((,class (:inherit default))))


### PR DESCRIPTION
Both faces used "white" as foreground color, making them unreadable in solarized-light.

This pull request changes their foreground color to `solarized-fg' making them readable in -dark and -light.
