### PR TITLE
Add ediff and improve diff

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -303,9 +303,9 @@
      `(custom-state ((,class (:foreground ,green))))
 
      ;; diff
-     `(diff-added ((,class (:foreground ,green))))
-     `(diff-changed ((,class (:foreground ,yellow))))
-     `(diff-removed ((,class (:foreground ,red))))
+     `(diff-added ((,class (:foreground ,green :background ,solarized-bg))))
+     `(diff-changed ((,class (:foreground ,yellow :background ,solarized-bg))))
+     `(diff-removed ((,class (:foreground ,red :background ,solarized-bg))))
      `(diff-header ((,class (:background ,solarized-bg))))
      `(diff-file-header
        ((,class (:background ,solarized-bg :foreground ,solarized-fg :weight bold))))


### PR DESCRIPTION
Hi,

Ediffs are almost completely unreadable, and white non-central chunks are blinding, especially in terminal.

![old](http://vitalie.spinu.info/tmp/ediff1.png)

With this patch it is still not perfect, but at least readable and not dazzling anymore. It's the best I could get with default solorized colors. 

![old](http://vitalie.spinu.info/tmp/ediff2.png)

Second commit improves the diff colors.  I have removed the default diff-added, diff-changed and diff-removed annoying background.

Two reasons:
1.  With background, diffs are more difficult to read.
2. In magit buffers, where highlighting is used to emphasize the current
   chunk, current chunk actually becomes less highlighted. During movement
   between chunks everything blinks and it is not clear where the central chunk is. 

Before:
![old](http://vitalie.spinu.info/tmp/diff1.png)

After:
![old](http://vitalie.spinu.info/tmp/diff2.png)
