### PR TITLE
Remove 'unspecific' from ansi-term-color-vector

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -959,7 +959,7 @@
      theme-name
      `(ansi-color-names-vector [,solarized-bg ,red ,green ,yellow
                                              ,blue ,magenta ,cyan ,solarized-fg])
-     `(ansi-term-color-vector [unspecific ,base01 ,red ,green ,yellow ,blue ,magenta ,cyan ,base03])
+     `(ansi-term-color-vector [,base01 ,red ,green ,yellow ,blue ,magenta ,cyan ,base03])
      ;; fill-column-indicator
      `(fci-rule-color ,solarized-hl)
 


### PR DESCRIPTION
Probably just a typo, fixes Issue #87 for me at least on Emacs 24.2.91.1
