### PR TITLE
ansi-term-color-vector fix

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -959,7 +959,8 @@
      theme-name
      `(ansi-color-names-vector [,solarized-bg ,red ,green ,yellow
                                              ,blue ,magenta ,cyan ,solarized-fg])
-     `(ansi-term-color-vector [,base01 ,red ,green ,yellow ,blue ,magenta ,cyan ,base03])
+     `(ansi-term-color-vector [,solarized-bg ,solarized-bg ,red ,green ,yellow 
+                                             ,blue ,magenta ,cyan ,solarized-fg])
      ;; fill-column-indicator
      `(fci-rule-color ,solarized-hl)
 


### PR DESCRIPTION
The ansi-term-color-vector needs nine items (unspecified and then
eight colors) in it.  Also the settings for black and white were not
taking into account whether the theme was light or dark.
