### PR TITLE
Added cscope faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -299,6 +299,13 @@
      `(clojure-test-error-face ((t (:foreground ,red :weight bold :underline t))))
      `(clojure-test-success-face ((t (:foreground ,green :weight bold :underline t))))
 
+     ;; cscope
+     `(cscope-file-face ((,class (:foreground ,green :weight bold))))
+     `(cscope-function-face ((,class (:foreground ,blue))))
+     `(cscope-line-number-face ((,class (:foreground ,yellow))))
+     `(cscope-line-face ((,class (:foreground ,solarized-fg))))
+     `(cscope-mouse-face ((,class (:background ,blue :foreground ,solarized-fg))))
+
      ;; ctable
      `(ctbl:face-cell-select ((,class (:background ,blue :foreground ,solarized-bg))))
      `(ctbl:face-continue-bar ((,class (:background ,solarized-hl :foreground ,solarized-bg))))
@@ -1039,14 +1046,7 @@
        ((,class (:foreground ,solarized-comments :background ,solarized-comments))))
 
      ;; zencoding
-     `(zencoding-preview-input ((,class (:background ,solarized-hl :box ,solarized-emph))))
-
-     ;; cscope
-     `(cscope-file-face ((,class (:foreground ,green :weight bold))))
-     `(cscope-function-face ((,class (:foreground ,blue))))
-     `(cscope-line-number-face ((,class (:foreground ,yellow))))
-     `(cscope-line-face ((,class (:foreground ,solarized-fg))))
-     `(cscope-mouse-face ((,class (:background ,blue :foreground ,solarized-fg)))))
+     `(zencoding-preview-input ((,class (:background ,solarized-hl :box ,solarized-emph)))))
 
 
     (custom-theme-set-variables


### PR DESCRIPTION
Use solarized palette for cscope (`xcscope.el`).
Fixes #58.
Example included.

![cscope-solarized](https://f.cloud.github.com/assets/121621/424401/b05081fe-ad88-11e2-8c7a-2d2a28273775.PNG)
