### PR TITLE
Use wave underlines

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -362,24 +362,41 @@
 
      ;; flymake
      `(flymake-errline
-       ((,class (:foreground ,red-hc :background ,red-lc :weight bold :underline t))))
-     `(flymake-infoline ((,class (:foreground ,green-hc :background ,green-lc))))
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,red)))
+        (,class (:foreground ,red-hc :background ,red-lc :weight bold :underline t))))
+     `(flymake-infoline
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,green)))
+        (,class (:foreground ,green-hc :background ,green-lc))))
      `(flymake-warnline
-       ((,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold :underline t))))
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,yellow)))
+        (,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold :underline t))))
 
      ;; flycheck
      `(flycheck-error
-       ((,class (:foreground ,red-hc :background ,red-lc :weight bold :underline t))))
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,red)))
+        (,class (:foreground ,red-hc :background ,red-lc :weight bold :underline t))))
      `(flycheck-warning
-       ((,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold :underline t))))
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,yellow)))
+        (,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold :underline t))))
      `(flycheck-fringe-error
        ((,class (:foreground ,red-hc :background ,red-lc :weight bold))))
      `(flycheck-fringe-warning
        ((,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold))))
 
      ;; flyspell
-     `(flyspell-duplicate ((,class (:foreground ,yellow :weight bold :underline t))))
-     `(flyspell-incorrect ((,class (:foreground ,red :weight bold :underline t))))
+     `(flyspell-duplicate
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,yellow)))
+        (,class (:foreground ,yellow :weight bold :underline t))))
+     `(flyspell-incorrect
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,red)))
+        (,class (:foreground ,red :weight bold :underline t))))
 
      ;; erc
      `(erc-action-face ((,class (:inherit erc-default-face))))


### PR DESCRIPTION
Use wave underlines instead of foreground colors to highlight background errors from the following on-the-fly checkers:
- Flyspell
- Flymake
- Flycheck

Wave underlines are less intrusive than foreground colors, thus less distracting and better suited for this kind of background errors that should not draw the user's focus away from the text she is editing.  Most notably they preserve foreground, background and style from font locking, and thus do not break syntax highlighting.

Moreover, these underlines are the established standard user interface for this kind of highlighting, and are used by many other editors.  Using them in this theme, too, provides a more unified user interface, specially if the user is using other environments with Solarized colors, too (e.g. Eclipse or IntelliJ with Solarized themes).

![bildschirmfoto 2013-05-21 um 17 14 25](https://f.cloud.github.com/assets/224922/542711/27c6579a-c229-11e2-9835-3d1dfbf76f0f.png)

Wave underlines are not available on text terminals, or Emacs before 24.3.  In these cases, the code simply falls back to the old faces with foreground and background highlighting.  

I tested the new code only on Emacs 24.3.  Though I am pretty sure that it works on Emacs 24.2, too, you should probably try it first.
