### PR TITLE
Set mouse pointer color

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -127,6 +127,8 @@
      `(match ((,class (:background ,solarized-hl :foreground ,solarized-emph :weight bold))))
      `(cursor ((,class (:foreground ,solarized-bg :background ,solarized-fg
                                     :inverse-video t))))
+     `(mouse ((,class (:foreground ,solarized-bg :background ,solarized-fg
+				   :inverse-video t))))
      `(escape-glyph-face ((,class (:foreground ,red))))
      `(fringe ((,class (:foreground ,solarized-fg :background ,solarized-bg))))
      `(header-line ((,class (:foreground ,yellow


### PR DESCRIPTION
I find the default black mouse pointer to be too hard to see on the dark theme. This sets the pointer color to match the text color.
