### PR TITLE
WIP: Group customizations

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -111,6 +111,10 @@ Also affects linum-mode background."
 		 :type ',(get sgc 'custom-type)
 		 :group ',(intern (concat sp prefix-str)))))
 	  customs))))
+
+(solarized-declare-customizations-for-group "Org Mode" org)
+
+
 (defun create-solarized-theme (variant theme-name &optional childtheme)
   "Create a VARIANT of the theme named THEME-NAME.
 
@@ -970,7 +974,7 @@ customize the resulting theme."
      ;; org-mode
      `(org-agenda-structure
        ((,class (:foreground ,solarized-emph :background ,solarized-hl
-                             :weight bold :slant normal :inverse-video nil :height ,solarized-height-plus-1
+                             :weight bold :slant normal :inverse-video nil :height ,solarized-org-height-plus-1
                              :underline nil
                              :box (:line-width 2 :color ,solarized-bg)))))
      `(org-agenda-calendar-event ((,class (:foreground ,solarized-emph))))
@@ -1000,13 +1004,13 @@ customize the resulting theme."
      `(org-formula ((,class (:foreground ,yellow))))
      `(org-headline-done ((,class (:foreground ,green))))
      `(org-hide ((,class (:foreground ,solarized-bg))))
-     `(org-level-1 ((,class (:inherit ,s-variable-pitch :height ,solarized-height-plus-4
+     `(org-level-1 ((,class (:inherit ,s-variable-pitch :height ,solarized-org-height-plus-4
                                       :foreground ,orange))))
-     `(org-level-2 ((,class (:inherit ,s-variable-pitch :height ,solarized-height-plus-3
+     `(org-level-2 ((,class (:inherit ,s-variable-pitch :height ,solarized-org-height-plus-3
                                       :foreground ,green))))
-     `(org-level-3 ((,class (:inherit ,s-variable-pitch :height ,solarized-height-plus-2
+     `(org-level-3 ((,class (:inherit ,s-variable-pitch :height ,solarized-org-height-plus-2
                                       :foreground ,blue))))
-     `(org-level-4 ((,class (:inherit ,s-variable-pitch :height ,solarized-height-plus-1
+     `(org-level-4 ((,class (:inherit ,s-variable-pitch :height ,solarized-org-height-plus-1
                                       :foreground ,yellow))))
      `(org-level-5 ((,class (:inherit ,s-variable-pitch
                                       :foreground ,cyan))))
@@ -1046,7 +1050,7 @@ customize the resulting theme."
      `(org-column-title ((,class (:background ,solarized-hl :underline t :weight bold))))
      `(org-date-selected ((,class (:foreground ,red :inverse-video t))))
      `(org-document-info ((,class (:foreground ,solarized-fg))))
-     `(org-document-title ((,class (:foreground ,solarized-emph  :weight bold :height ,solarized-height-plus-4))))
+     `(org-document-title ((,class (:foreground ,solarized-emph  :weight bold :height ,solarized-org-height-plus-4))))
      `(org-drawer ((,class (:foreground ,cyan))))
      `(org-footnote ((,class (:foreground ,magenta :underline t))))
      `(org-latex-and-export-specials ((,class (:foreground ,orange))))


### PR DESCRIPTION
This is the basic idea that allows the user to customize on a per-group of faces:

```
(setq solarized-height-plus-1 1.5) ;; This affects everything
(setq solarized-org-height-plus-2 1.0) ;; This is just for Org Mode
```

There is a problem with `solarized-use-variable-pitch` though. It is indirectly used through `s-variable-pitch` which is an ad-hoc variable that contains the real value that will be used on the face definition. We could either:
- define similar variables for all relevant groups, which is tiresome
- remove `solarized-use-variable-pitch` and define a new customization (let's say `solarized-pitch`) that would contain the actual value: `variable-pitch`, `fixed-pitch` or `default`. Doing this has the advantages of making `solarized-pitch` consistent with the other customizations (in the sense that the value you set is the value actually used) plus allowing for `fixed-pitch` makes possible for the user to override the default value of the inherited face when it has `variable-pitch`. The obvious disadvantage is that people currently using `solarized-use-variable-pitch` would have to adapt their configuration.
