### PR TITLE
Add perspective colours

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1486,6 +1486,9 @@ customize the resulting theme."
      ;; parenfaceu
      `(paren-face  ((,class (:foreground ,base01))))
 
+     ;; perspective
+     `(persp-selected-face ((,class (:foreground ,yellow))))
+
      ;; pretty-mode
      `(pretty-mode-symbol-face  ((,class (:foreground ,yellow :weight normal))))
 


### PR DESCRIPTION
[perspective](https://github.com/nex3/perspective-el) adds a face for the selected 'perspective' in the modeline. I made it yellow to fit in with the other mode-line highlights, but that might just be because I'm using smart-mode-line.
