### PR TITLE
making enh-ruby-op-face visible

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -395,7 +395,7 @@ customize the resulting theme."
      `(enh-ruby-string-delimiter-face ((,class (:foreground ,yellow))))
      `(enh-ruby-heredoc-delimiter-face ((,class (:inherit enh-ruby-string-delimiter-face))))
      `(enh-ruby-regexp-delimiter-face ((,class (:inherit enh-ruby-string-delimiter-face))))
-     `(enh-ruby-op-face ((,class (:inherit default))))
+     `(enh-ruby-op-face ((,class (:foreground ,base0))))
      `(erm-syn-errline ((,class (:inherit flymake-errline))))
      `(erm-syn-warnline ((,class (:inherit flymake-warnline))))
 


### PR DESCRIPTION
### Before

notice things like :: and < on the class definition line 
![before](https://cloud.githubusercontent.com/assets/1127553/3565062/2a9d1f50-0aa6-11e4-8563-2634133412f4.png)
### After

![after](https://cloud.githubusercontent.com/assets/1127553/3565063/2c22dd10-0aa6-11e4-88a8-918a09f8cd96.png)
