### PR TITLE
Fix diff-refine-* colors for highlighting Magit hunks.

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -632,9 +632,12 @@ customize the resulting theme."
      `(diff-header ((,class (:background ,base03))))
      `(diff-file-header
        ((,class (:background ,base03 :foreground ,base0 :weight bold))))
-     `(diff-refine-added ((,class :foreground ,base03 :background ,green)))
-     `(diff-refine-change ((,class :foreground ,base03 :background ,blue)))
-     `(diff-refine-removed ((,class (:foreground ,base03 :background ,red))))
+     `(diff-refine-added ((,class (:foreground ,green :background ,base03
+                                               :inverse-video t))))
+     `(diff-refine-change ((,class (:foreground ,blue :background ,base03
+                                                :inverse-video t))))
+     `(diff-refine-removed ((,class (:foreground ,red :background ,base03
+                                                 :inverse-video t))))
 
      ;; ediff
      `(ediff-fine-diff-A ((,class (:background ,orange-lc))))


### PR DESCRIPTION
Hi!
I prefer the highlighting of hunks for Magit Mode, i.e.,

``` lisp
;; Show fine (word-granularity) differences within diff hunks
(setq magit-diff-refine-hunk 'all)
```

But the result of the overlapping of `magit-diff-*` and `diff-refine-*` colors is insufficient. The proposed fix should improve the highlighting. There are two screenshots showing the difference.

Old highlighting:
![magit-diff-old](https://cloud.githubusercontent.com/assets/2260430/4444123/3baaabc0-47ee-11e4-82fb-4af548a7691e.png)
New highlighting:
![magit-diff-new](https://cloud.githubusercontent.com/assets/2260430/4444131/5c8b2b58-47ee-11e4-8c47-96c82f86d131.png)

Best regards,
Vladimir.
