### PR TITLE
use proper section headings to separate packages

### DIFF
--- a/solarized-theme-utils.el
+++ b/solarized-theme-utils.el
@@ -63,10 +63,11 @@ in the format of solarized-theme.el."
                        (if (get face 'theme-face)
                            (format " ;; Already set by current theme!")
                          "")))))
-	  faces)))
+          faces)))
 
 ;; Local Variables:
 ;; byte-compile-warnings: (not cl-functions)
+;; indent-tabs-mode: nil
 ;; End:
 (provide 'solarized-theme-utils)
 ;;; solarized-theme-utils.el ends here

--- a/solarized.el
+++ b/solarized.el
@@ -2027,6 +2027,7 @@ customize the resulting theme."
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; eval: (when (fboundp 'rainbow-mode) (rainbow-mode 1))
+;; indent-tabs-mode: nil
 ;; fill-column: 95
 ;; End:
 ;;; solarized.el ends here


### PR DESCRIPTION
```
Instead of e.g.

     ;; package

use

;;;;; package

This allows collapsing sections similar to how this is done in Org
mode.  The outshine minor-mode can be used to achieve them same in
Emacs-Lisp and other major-modes.

The "Theme Faces" section has to subsections "Built-in" and
"Third-party".  Unfortunately the latter contains many subsubsections
for sections that are actually part of Emacs.  That should be fixed
over time.
```

Just like I did many moons ago for zenburn.

So far I have only done this for the light variant. If you are inclined to merge this, then I can also do the dark variant.
