### PR TITLE
solarized-theme.el: only require `solarized' not the theme libraries

### DIFF
--- a/solarized-theme.el
+++ b/solarized-theme.el
@@ -1,4 +1,2 @@
-(require 'solarized-dark-theme)
-(require 'solarized-light-theme)
-
+(require 'solarized)
 (provide 'solarized-theme)


### PR DESCRIPTION
Doing so would cause both themes to be loaded, then `solarized-theme.el` is loaded (why would one do that?) or when it is byte-compiled.

I don't know why you were loading these to libraries, maybe that is required depending on how a user activates the theme. I doubt it though, and if it were so then that would need fixing. I guess that `solarized-theme.el` only exists to pacify Melpa/package.el, in which case it would have to contain nothing but the provide form (a library header would be nice though).
