### PR TITLE
Make company-mode annotations stand out more

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -570,6 +570,7 @@ customize the resulting theme."
      `(company-tooltip-mouse ((,class (:background ,cyan-hc :foreground ,cyan-lc))))
      `(company-tooltip-common ((,class (:foreground ,base1 :underline t))))
      `(company-tooltip-common-selection ((,class (:foreground ,base1 :underline t))))
+     `(company-tooltip-annotation ((,class (:foreground ,yellow :background ,base02))))
      `(company-scrollbar-fg ((,class (:foreground ,base03 :background ,base0))))
      `(company-scrollbar-bg ((,class (:background ,base02 :foreground ,cyan))))
      `(company-preview ((,class (:background ,base02 :foreground ,cyan))))

--- a/solarized.el
+++ b/solarized.el
@@ -570,7 +570,7 @@ customize the resulting theme."
      `(company-tooltip-mouse ((,class (:background ,cyan-hc :foreground ,cyan-lc))))
      `(company-tooltip-common ((,class (:foreground ,base1 :underline t))))
      `(company-tooltip-common-selection ((,class (:foreground ,base1 :underline t))))
-     `(company-tooltip-annotation ((,class (:foreground ,yellow :background ,base02))))
+     `(company-tooltip-annotation ((,class (:foreground ,base1 :background ,base02))))
      `(company-scrollbar-fg ((,class (:foreground ,base03 :background ,base0))))
      `(company-scrollbar-bg ((,class (:background ,base02 :foreground ,cyan))))
      `(company-preview ((,class (:background ,base02 :foreground ,cyan))))


### PR DESCRIPTION
company-mode recently added annotation support for some meta-level information, e.g. function parameters, here shown with company-go as a backend.

![2015-02-20-122910_666x208_scrot](https://cloud.githubusercontent.com/assets/174208/6286996/271e21fc-b916-11e4-9a65-1d5d8d57a439.png)

The default face is a red foreground. This is unreadable in the dark scheme and clashes with the colour scheme.

This PR modifies it to a clear yellow which looks nice on both colour schemes.

![2015-02-20-150450_652x199_scrot](https://cloud.githubusercontent.com/assets/174208/6287012/440865e8-b916-11e4-98b8-11cf154f2329.png)

I tried other colours (green, magenta, violet) that would stand out more but found that the yellow one worked  best.