### PR TITLE
Fix widget-field color

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -307,6 +307,7 @@ customize the resulting theme."
      `(error ((,class (:foreground ,orange))))
      `(lazy-highlight ((,class (:foreground ,base03 :background ,yellow
                                             :weight normal))))
+     `(widget-field ((,class (:background ,base02))))
      '(button ((t (:underline t))))
 ;;;;; compilation
      `(compilation-column-face ((,class (:foreground ,cyan :underline nil))))


### PR DESCRIPTION
The default color of widget fields (like in customize) was unreadable
with Solarized. This background color seems reasonably close to the
default Emacs look of a contrasting background, no style.

I'll admit that a box with style "pressed-button" looks pretty good too.