### PR TITLE
Subtle line numbers with `distinct-fringe-background` on

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -255,8 +255,7 @@ customize the resulting theme."
                                'variable-pitch 'default))
          (s-fringe-bg (if solarized-distinct-fringe-background
                           base02 base03))
-         (s-fringe-fg (if solarized-distinct-fringe-background
-                          base0 base01))
+         (s-fringe-fg base01)
 
 
          (s-header-line-fg (if solarized-high-contrast-mode-line


### PR DESCRIPTION
This brings the line number column to parity with the official Solarized screenshots and the Vim version (and probably the rest), when `solarized-distinct-fringe-background` is turned on. In transitioning from Vim to Emacs, it bugged me way more than it should have :smile:.

#### Before:
![screen shot 2015-03-25 at 6 14 18 pm](https://cloud.githubusercontent.com/assets/889991/6836952/75632be8-d31d-11e4-86a4-a6452b6adeb4.png)
![screen shot 2015-03-25 at 6 14 23 pm](https://cloud.githubusercontent.com/assets/889991/6836954/78e8a4b4-d31d-11e4-8a25-3bb8d0330a9f.png)
#### After:
![screen shot 2015-03-25 at 6 12 46 pm](https://cloud.githubusercontent.com/assets/889991/6836966/9132d788-d31d-11e4-9e63-36091a1404a1.png)
![screen shot 2015-03-25 at 6 13 07 pm](https://cloud.githubusercontent.com/assets/889991/6836969/933f5c18-d31d-11e4-9acc-39d303ad3403.png)

