### PR TITLE
Add powerline support

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1578,6 +1578,19 @@ customize the resulting theme."
      `(popup-scroll-bar-background-face ((,class (:background ,base01))))
      `(popup-scroll-bar-foreground-face ((,class (:background ,base1))))
      `(popup-tip-face ((,class (:background ,base02 :foreground ,base0))))
+;;;;; powerline
+     `(powerline-active1 ((,class ,(if solarized-high-contrast-mode-line
+                                       `(:background ,base00 :foreground ,base03)
+                                       `(:background ,base03 :foreground ,base00)))))
+     `(powerline-active2 ((,class ,(if solarized-high-contrast-mode-line
+                                       `(:background ,base01 :foreground ,base03)
+                                       `(:background ,base02 :foreground ,base00)))))
+     `(powerline-inactive1 ((,class ,(if solarized-high-contrast-mode-line
+                                         `(:background ,base03 :foreground ,base1)
+                                         `(:background ,base02 :foreground ,base01)))))
+     `(powerline-inactive2 ((,class ,(if solarized-high-contrast-mode-line
+                                         `(:background ,base02 :foreground ,base1)
+                                         `(:background ,base03 :foreground ,base01)))))
 ;;;;; rainbow-blocks
      `(rainbow-blocks-depth-1-face ((,class (:foreground ,cyan))))
      `(rainbow-blocks-depth-2-face ((,class (:foreground ,yellow))))


### PR DESCRIPTION
Powerline uses the existing mode-line face and supplies [a few of its own faces](https://github.com/milkypostman/powerline/blob/master/powerline.el#L26-L32) which inherit from it and set their own gray backgrounds which don't work with Solarized. This PR adds two sets of colors, for when `solarized-high-contrast-mode-line` is `nil` and `t`.

#### Before:
![screen shot 2015-03-25 at 10 14 23 pm](https://cloud.githubusercontent.com/assets/889991/6839484/5de85df4-d33f-11e4-9c8b-a4bddb3df9a7.png)
![screen shot 2015-03-25 at 10 14 33 pm](https://cloud.githubusercontent.com/assets/889991/6839488/7b3d907c-d33f-11e4-8a09-ff5049bc9205.png)
![screen shot 2015-03-25 at 10 15 22 pm](https://cloud.githubusercontent.com/assets/889991/6839489/7f3a1a7e-d33f-11e4-882b-61fa79fc90c8.png)

#### After:
![screen shot 2015-03-25 at 10 26 23 pm](https://cloud.githubusercontent.com/assets/889991/6839492/89f86f2e-d33f-11e4-99b7-04b2d8c6cc7c.png)
![screen shot 2015-03-25 at 10 26 33 pm](https://cloud.githubusercontent.com/assets/889991/6839494/89fb055e-d33f-11e4-8c63-401050d0f861.png)
![screen shot 2015-03-25 at 10 27 04 pm](https://cloud.githubusercontent.com/assets/889991/6839495/89fb7fc0-d33f-11e4-9b74-3f9e62f6037b.png)
![screen shot 2015-03-25 at 10 27 11 pm](https://cloud.githubusercontent.com/assets/889991/6839493/89fac292-d33f-11e4-94c2-8596e7460911.png)
