### PR TITLE
Add cider-repl-err-output-face

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -557,6 +557,8 @@ customize the resulting theme."
      `(clojure-test-failure-face ((t (:foreground ,orange :weight bold :underline t))))
      `(clojure-test-error-face ((t (:foreground ,red :weight bold :underline t))))
      `(clojure-test-success-face ((t (:foreground ,green :weight bold :underline t))))
+;;;;; cider-repl-mode
+     `(cider-repl-err-output-face ((t (:inherit ,font-lock-warning-face :underline nil))))
 ;;;;; cider-test-mode
      `(cider-test-failure-face ((t (:foreground ,orange :weight bold :underline t))))
      `(cider-test-error-face ((t (:foreground ,red :weight bold :underline t))))


### PR DESCRIPTION
Generally the faces for `cider-repl-mode` seem fine, but this particular one inherits from `font-lock-warning-face` which is underlined in the theme. One alternative is to remove the underline from that face entirely, or add an option to use underline less. FWIW I've only ever found it noisy/distracting. Since the theme uses red/orange pretty sparingly, anything in that colour tends to stand out anyway without being underlined.

Before:
![screenshot 2015-03-29 22 03 32](https://cloud.githubusercontent.com/assets/1759291/6887732/545d82f4-d660-11e4-8d99-c4befb044172.png)

After:
![screenshot 2015-03-29 22 04 51](https://cloud.githubusercontent.com/assets/1759291/6887733/567e0ac2-d660-11e4-875d-c64cb061f3ab.png)