### PR TITLE
Tweak mode-line faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -267,19 +267,21 @@ customize the resulting theme."
 
          (s-mode-line-fg (if solarized-high-contrast-mode-line
                              base03 base0))
+         (s-mode-line-buffer-id-fg (if solarized-high-contrast-mode-line
+                                       'unspecified base1))
          (s-mode-line-bg (if solarized-high-contrast-mode-line
                              base0 base02))
          (s-mode-line-underline (if solarized-high-contrast-mode-line
-                                    nil s-line))
+                                    base0 s-line))
 
-         (s-mode-line-buffer-id-fg (if solarized-high-contrast-mode-line
-                                       'unspecified base1))
          (s-mode-line-inactive-fg (if solarized-high-contrast-mode-line
                                       base0 base01))
          (s-mode-line-inactive-bg (if solarized-high-contrast-mode-line
                                       base02 base03))
-         (s-mode-line-inactive-bc (if solarized-high-contrast-mode-line
-                                               base02 base02)))
+         (s-mode-line-inactive-overline (if solarized-high-contrast-mode-line
+                                               s-line base02))
+         (s-mode-line-inactive-underline (if solarized-high-contrast-mode-line
+                                               base01 s-line)))
 ;;; Theme Faces
     (custom-theme-set-faces
      theme-name
@@ -415,18 +417,14 @@ customize the resulting theme."
                                 :underline ,s-mode-line-underline
                                 :foreground ,s-mode-line-fg
                                 :background ,s-mode-line-bg
-                                :box (:line-width 1 :color ,s-mode-line-bg
-                                                  :style unspecified)
                                 ))))
      `(mode-line-buffer-id ((,class (:foreground ,s-mode-line-buffer-id-fg :weight bold))))
      `(mode-line-inactive
        ((,class (:inverse-video unspecified
-                                :overline ,s-mode-line-inactive-bc
-                                :underline ,s-mode-line-underline
+                                :overline ,s-mode-line-inactive-overline
+                                :underline ,s-mode-line-inactive-underline
                                 :foreground ,s-mode-line-inactive-fg
                                 :background ,s-mode-line-inactive-bg
-                                :box (:line-width 1 :color ,s-mode-line-inactive-bg
-                                                  :style unspecified)
                                 ))))
      `(header-line
        ((,class (:inverse-video unspecified


### PR DESCRIPTION
This PR
1. removes :box from mode-line faces
2. adds mode-line-inactive overline/underline colors

The reason for (1) is that the :box property isn't applied the same way to _xpm images_ or _non-text spaces_ the same way as it is applied to normal text within the mode-line. Or something like that. This resulted in weird underline/overline discontinuities in the presence of xpm images or other non-text stuff in the mode-line when `high-contrast-mode-line` was `nil` (see below). Powerline uses xpm images as separators. 

Appropriate underline/overline properties are now relied upon exclusively, and IIUC, were responsible for the lines seen before this PR anyway in normal (text) mode-lines. To my knowledge, this shouldn't affect normal mode-lines.

The reason for (2) is to specify appropriate underlines/overlines in support of (1). Colors shouldn't change except that the inactive mode-line now gets an `overline` of `s-line` and an `underline` of `base01` when `high-contrast-mode-line` is `t`, where before the `overline` and `underline` would both be `base02` in that case, and difficult to see (see below).
#### Before:
- with high contrast: ![screen shot 2015-04-01 at 12 02 49 pm](https://cloud.githubusercontent.com/assets/889991/6946107/0441d190-d86c-11e4-8147-ee6b83be5ad3.png)
- without high contrast: ![screen shot 2015-04-01 at 12 03 35 pm](https://cloud.githubusercontent.com/assets/889991/6946108/044241f2-d86c-11e4-917b-96bfb40bdfbb.png)
#### After:
- with high contrast: ![screen shot 2015-04-01 at 11 59 11 am](https://cloud.githubusercontent.com/assets/889991/6946109/08c1e3ea-d86c-11e4-889a-090d3f4b4a3c.png)
- without high contrast: ![screen shot 2015-04-01 at 12 00 28 pm](https://cloud.githubusercontent.com/assets/889991/6946110/08c1ebc4-d86c-11e4-9220-09f84027c1e9.png)
