### PR TITLE
Add coloring for highlight-numbers

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1079,6 +1079,8 @@ customize the resulting theme."
 ;;;;; highlight-indentation
      `(highlight-indentation-face ((,class (:background ,base02))))
      `(highlight-indentation-current-column-face((,class (:background ,base02))))
+;;;;; highlight-numbers
+     `(highlight-numbers-number ((,class (:foreground ,violet :bold nil))))
 ;;;;; highlight-symbol
      `(highlight-symbol-face ((,class (:foreground ,magenta))))
 ;;;;; hl-line-mode


### PR DESCRIPTION
Hi, this pull request sets the color for the "highlight-numbers" package (https://github.com/Fanael/highlight-numbers), which highlights numbers in source code. I set it to the solarized "violet" color.

Screen shot for the dark theme: 
![example](https://cloud.githubusercontent.com/assets/4155393/8666155/3e300408-29bb-11e5-94f3-aff423bb0e18.png)

Screen shot for the light theme:
![example2](https://cloud.githubusercontent.com/assets/4155393/8666156/4507a84e-29bb-11e5-8f47-6216a744f27b.png)
