### PR TITLE
Do not depend on the f and s packages for tests

### DIFF
--- a/tests/emacs-visual-test.el
+++ b/tests/emacs-visual-test.el
@@ -1,27 +1,22 @@
 ;;; emacs-visual-test.el ---
 
-;;; Commentary:
-;;
-
 (load-file "init.el")
-(require 's)
 (require 'dash)
-(require 'f)
 (setq header-line-format "header line content")
 
 (defconst screenshots-directory
-  (f-expand "screenshots" tests-directory))
+  (expand-file-name "screenshots" tests-directory))
 
 (defconst test-files-directory
-  (f-expand "test-files" tests-directory))
+  (expand-file-name "test-files" tests-directory))
 
 (defun visual-test-find-file (  name)
-  (find-file (f-expand name test-files-directory)))
+  (find-file (expand-file-name name test-files-directory)))
 
 (defun visual-test-screenshot ()
   (call-process "scrot" nil nil nil "-u"
-                (f-expand "screenshot-%Y-%m-%d_%H-%M-%S_$wx$h.png"
-                          screenshots-directory))
+                (expand-file-name "screenshot-%Y-%m-%d_%H-%M-%S_$wx$h.png"
+                                  screenshots-directory))
   (message "saved screenshot"))
 
 ;; (setq solarized-high-contrast-mode-line t)
@@ -35,7 +30,6 @@
 (goto-char 27)
 (call-interactively 'ispell-complete-word)
 
-
 (run-with-idle-timer 2 nil
                      '(lambda ()
                         (visual-test-screenshot)
@@ -43,8 +37,6 @@
                         ;; (kill-buffer)
                         ;; (kill-emacs)
                         ))
-
-
 
 (provide 'emacs-visual-test)
 


### PR DESCRIPTION
```
`s' was not used directly but is a dependency of `f'.  The only
function from `f' which was used here is `f-expand' which is
defined like so:

  (defun f-expand (path &optional dir)
    "Expand PATH relative to DIR (or `default-directory')."
    (directory-file-name (expand-file-name path dir)))

Since the `directory-file-name' part is irrelevant in our usage,
we might as well just use `expand-file-name'.

Also remove some empty lines and the empty and not properly
terminated "Commentary" section.
```