### PR TITLE
Add faces for minibuffer hints of git-timemachine

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -934,6 +934,9 @@ customize the resulting theme."
      `(git-gutter-fr+-modified ((,class (:foreground ,blue :weight bold))))
 ;;;;; git-rebase
      `(git-rebase-hash ((,class (:foreground ,base01))))
+;;;;; git-timemachine
+     `(git-timemachine-minibuffer-author-face ((,class (:foreground ,orange))))
+     `(git-timemachine-minibuffer-detail-face ((,class (:foreground ,yellow))))
 ;;;;; go-direx
      `(go-direx-header ((,class (:foreground ,blue))))
      `(go-direx-label ((,class (:foreground ,green))))


### PR DESCRIPTION
See https://github.com/pidu/git-timemachine for information about git-timemachine.

I picked `s-orange` and `s-yellow` for no other reason than that git-timemachine itself uses "orange" and "yellow" respectively for these faces.  I've read the devguide about `orange` but I looks good and I don't think a user could confuse this message with an error message:

![bildschirmfoto 2016-04-19 um 16 41 29](https://cloud.githubusercontent.com/assets/224922/14643172/968b3c7a-064d-11e6-925f-0a16183ce5a8.png)

However, if you'd like to use different colours—maybe there are standard colours for this kind of display—please tell me and I'll update the pull request.