### PR TITLE
Autoload solarized-color-blend to avoid breaking customisation

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -139,6 +139,7 @@ RED, GREEN, and BLUE should be numbers between 0.0 and 1.0, inclusive."
   (format "#%02x%02x%02x"
           (* red 255) (* green 255) (* blue 255)))
 
+;;;###autoload
 (defun solarized-color-blend (color1 color2 alpha)
   "Blends COLOR1 onto COLOR2 with ALPHA.
 


### PR DESCRIPTION
When saving customisation after enabling this theme, the saved settings for certain variables (e.g. the highlight symbol faces) get set to forms which reference solarized-color-blend. If the saved theme is later switched to a different theme, then those variables settings break, because solarized will not be loaded at the time they are evaluated.
