### PR TITLE
Don't duplicate code from color.el

### DIFF
--- a/solarized-theme-pkg.el
+++ b/solarized-theme-pkg.el
@@ -2,4 +2,4 @@
   "solarized-theme"
   "1.2.2"
   "The Solarized color theme, ported to Emacs."
-  '((cl-lib "0.5") (dash "2.6.0")))
+  '((emacs "24.1") (cl-lib "0.5") (dash "2.6.0")))

--- a/solarized.el
+++ b/solarized.el
@@ -40,6 +40,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'color)
 
 ;;; Options
 
@@ -117,28 +118,6 @@ Related discussion: https://github.com/bbatsov/solarized-emacs/issues/158"
 
 ;;; Utilities
 
-(defun solarized-color-name-to-rgb (color &optional frame)
-  "Convert COLOR string to a list of normalized RGB components.
-COLOR should be a color name (e.g. \"white\") or an RGB triplet
-string (e.g. \"#ff12ec\").
-
-Normally the return value is a list of three floating-point
-numbers, (RED GREEN BLUE), each between 0.0 and 1.0 inclusive.
-
-Optional argument FRAME specifies the frame where the color is to be
-displayed.  If FRAME is omitted or nil, use the selected frame.
-If FRAME cannot display COLOR, return nil."
-  ;; `colors-values' maximum value is either 65535 or 65280 depending on the
-  ;; display system.  So we use a white conversion to get the max value.
-  (let ((valmax (float (car (color-values "#ffffff")))))
-    (mapcar (lambda (x) (/ x valmax)) (color-values color frame))))
-
-(defun solarized-color-rgb-to-hex  (red green blue)
-  "Return hexadecimal notation for the color RED GREEN BLUE.
-RED, GREEN, and BLUE should be numbers between 0.0 and 1.0, inclusive."
-  (format "#%02x%02x%02x"
-          (* red 255) (* green 255) (* blue 255)))
-
 ;;;###autoload
 (defun solarized-color-blend (color1 color2 alpha)
   "Blends COLOR1 onto COLOR2 with ALPHA.
@@ -147,11 +126,11 @@ COLOR1 and COLOR2 should be color names (e.g. \"white\") or RGB
 triplet strings (e.g. \"#ff12ec\").
 
 Alpha should be a float between 0 and 1."
-  (apply 'solarized-color-rgb-to-hex
+  (apply 'color-rgb-to-hex
          (-zip-with '(lambda (it other)
                        (+ (* alpha it) (* other (- 1 alpha))))
-                    (solarized-color-name-to-rgb color1)
-                    (solarized-color-name-to-rgb color2))))
+                    (color-name-to-rgb color1)
+                    (color-name-to-rgb color2))))
 
 ;;; Setup Start
 (defmacro solarized-with-color-variables (variant &rest body)


### PR DESCRIPTION
This theme targets Emacs 24, so it can simply directly use the color-name-to-rgb and color-rgb-to-hex, since those functions have been available in color.el since Emacs 24.1. In fact, the code removed by this commit has apparently been copied-and-pasted from there, and prefixed with "solarized-".