### PR TITLE
Make fci-mode line visible in light theme

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -2138,7 +2138,7 @@ customize the resulting theme."
      `(cua-global-mark-cursor-color ,cyan)
      `(cua-overwrite-cursor-color ,yellow)
 ;;;;; fill-column-indicator
-     `(fci-rule-color ,base02)
+     `(fci-rule-color ,s-line)
 ;;;;; magit
      `(magit-diff-use-overlays nil)
 ;;;;; nrepl-client


### PR DESCRIPTION
Use the proper color definition for the very thin line shown by `fci-mode`. The `s-line` definition is intended for exactly this purpose. The result is a visible line in the light theme, which is currently invisible.