### PR TITLE
magit: use colors in popup buffers

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1322,11 +1322,11 @@ customize the resulting theme."
      `(magit-diffstat-added              ((t (:foreground ,green))))
      `(magit-diffstat-removed            ((t (:foreground ,red))))
 ;;;;;; popup
-     `(magit-popup-heading             ((t (:foreground ,base1 :weight normal))))
-     `(magit-popup-key                 ((t (:foreground ,base1 :weight bold))))
-     `(magit-popup-argument            ((t (:foreground ,base1 :weight bold))))
-     `(magit-popup-disabled-argument   ((t (:foreground ,base01 :weight normal))))
-     `(magit-popup-option-value        ((t (:foreground ,base1 :weight bold))))
+     `(magit-popup-heading             ((t (:foreground ,yellow  :weight bold))))
+     `(magit-popup-key                 ((t (:foreground ,green-d :weight bold))))
+     `(magit-popup-argument            ((t (:foreground ,cyan-d  :weight bold))))
+     `(magit-popup-disabled-argument   ((t (:foreground ,base01  :weight normal))))
+     `(magit-popup-option-value        ((t (:foreground ,cyan    :weight bold))))
 ;;;;;; process
      `(magit-process-ok    ((t (:foreground ,green :weight bold))))
      `(magit-process-ng    ((t (:foreground ,red   :weight bold))))


### PR DESCRIPTION
This is the theme I personally use, which is why I made the necessary changes myself when I released Magit v2.1.

Shortly after you merged that, you also changed the faces used in Magit's popup buffers to be only black&white instead of using colors as I had intended. I pointed that out to you but you never responded. See b0b8cb1d5c2b1836fbc764ee4279cccec0510aac.

I have reverted that commit for my own use. I also use that patched version when creating Magit screenshots. I intend to add more screenshots, but first I am making another attempt to convince you to revert your change from a year ago.

Black&white version:

![bland](https://cloud.githubusercontent.com/assets/25046/17944444/0bfb69d4-6a40-11e6-97fb-07921f1917dd.png)

After applying this commit:

![color](https://cloud.githubusercontent.com/assets/25046/17944456/16d2b100-6a40-11e6-9bd1-7fdebe95c3f4.png)

I hope you will apply this commit as is, but if this is too fruit-salady for you, then I guess I can compromise. If necessary I will present my arguments for each of these changes (reverts), but I am hoping I can avoid that work.

So what do you think?
