### PR TITLE
use only background color for region selection

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -423,7 +423,7 @@ customize the resulting theme."
                                 :box (:line-width 2 :color ,s-header-line-bg
                                                   :style unspecified)
                                 ))))
-     `(region ((,class (:foreground ,base03 :background ,base1))))
+     `(region ((,class (:background ,base02))))
      `(secondary-selection ((,class (:background ,base02))))
 
      `(trailing-whitespace ((,class (:background ,red))))


### PR DESCRIPTION
I've found it annoying at times that selecting a region overwrites all the syntax highlighting (by setting a foreground color).

Would it be an option to set only a background color for a selected region? I've experimented a bit and I think `base02` would be the natural choice, `base01` is a bit too dark. Note that `base02` is also used for `secondary-selection`; not sure if that is a problem for people?
