### PR TITLE
magit-diff-file-heading-*: do not re-enforce boldness

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1305,9 +1305,9 @@ customize the resulting theme."
      `(magit-section-heading             ((t (:foreground ,yellow :weight bold))))
      `(magit-section-heading-selection   ((t (:foreground ,orange :weight bold))))
      `(magit-diff-file-heading           ((t (:weight bold))))
-     `(magit-diff-file-heading-highlight ((t (:background ,base02 :weight bold))))
+     `(magit-diff-file-heading-highlight ((t (:background ,base02))))
      `(magit-diff-file-heading-selection ((t (:background ,base02
-                                              :foreground ,orange :weight bold))))
+                                              :foreground ,orange))))
      `(magit-diff-hunk-heading
        ((t (:background ,(solarized-color-blend yellow base03 0.1)))))
      `(magit-diff-hunk-heading-highlight


### PR DESCRIPTION
Doing so would make the complete heading bold, but we only want the
parts to be bold that are already bold anyway, and they continue to
do be even if we don't explicitly say that it should be so.

You have to update Magit to see the effect of this change. The default faces had the same issue and I [fixed that just now](https://github.com/magit/magit/commit/a4b52516dfade3f43024ea476fc9c6c3c54cc507).