### PR TITLE
Use base02 for org-clock-overlay face

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1649,7 +1649,7 @@ customize the resulting theme."
      ;; latest additions
      `(org-agenda-dimmed-todo-face ((,class (:foreground ,base01))))
      `(org-agenda-restriction-lock ((,class (:background ,yellow))))
-     `(org-clock-overlay ((,class (:background ,yellow))))
+     `(org-clock-overlay ((,class (:background ,base02))))
      `(org-column ((,class (:background ,base02 :strike-through nil
                                         :underline nil :slant normal :weight normal :inherit default))))
      `(org-column-title ((,class (:background ,base02 :underline t :weight bold))))


### PR DESCRIPTION

Use base02 for `org-clock-overlay` face used by `org-clock-display`

**Original**

![screenshot_20161107_120002](https://cloud.githubusercontent.com/assets/65531/20067157/07c668fa-a4e2-11e6-8fe8-47ac448b46df.png)

**New**
![screenshot_20161107_120134](https://cloud.githubusercontent.com/assets/65531/20067178/200d577a-a4e2-11e6-9fde-ba28439175ab.png)
