### PR TITLE
Corrected README to set scale rather than absolute height

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ elisp code:
 (setq solarized-scale-org-headlines nil)
 
 ;; Avoid all font-size changes
-(setq solarized-height-minus-1 1)
-(setq solarized-height-plus-1 1)
-(setq solarized-height-plus-2 1)
-(setq solarized-height-plus-3 1)
-(setq solarized-height-plus-4 1)
+(setq solarized-height-minus-1 1.0)
+(setq solarized-height-plus-1 1.0)
+(setq solarized-height-plus-2 1.0)
+(setq solarized-height-plus-3 1.0)
+(setq solarized-height-plus-4 1.0)
 
 ```
 


### PR DESCRIPTION
Setting the height attribute to an integer sets the font height to an absolute value in units of 1/10 point. This patch fixes #251 by changing the README to use floats, thus setting the font scale instead.
