### PR TITLE
Make org-block-begin-line inherit from org-meta-line

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1610,7 +1610,7 @@ customize the resulting theme."
      `(org-agenda-done ((,class (:foreground ,base01 :slant italic))))
      `(org-archived ((,class (:foreground ,base01 :weight normal))))
      `(org-block ((,class (:foreground ,base01))))
-     `(org-block-begin-line ((,class (:foreground ,base01 :slant italic))))
+     `(org-block-begin-line ((,class (:inherit 'org-meta-line :foreground ,base01 :slant italic))))
      `(org-checkbox ((,class (:background ,base03 :foreground ,base0
                                           :box (:line-width 1 :style released-button)))))
      `(org-code ((,class (:foreground ,base01))))


### PR DESCRIPTION
In org-mode itself, `org-block-begin-line` inherits from `org-meta-line`, as does `org-block-end-line`, which ensures that the begin and end lines look the same.  Somehow that has not been the case in solarized-theme; this restores it.  

Thanks for your work on this theme!  Been using it for years and there's nothing better.  :)