### PR TITLE
Set indent of solarized-with-color-variables to defun

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -134,7 +134,7 @@ Alpha should be a float between 0 and 1."
 
 ;;; Setup Start
 (defmacro solarized-with-color-variables (variant &rest body)
-  (declare (indent 0))
+  (declare (indent defun))
   `(let* ((class '((class color) (min-colors 89)))
          (variant ,variant)
          (s-base03    "#002b36")


### PR DESCRIPTION
This sets the indent declaration to `defun` so that it's indented like other macros.  Thanks.