### PR TITLE
Set org-meta-line instead of org-block-begin-line

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1610,7 +1610,6 @@ customize the resulting theme."
      `(org-agenda-done ((,class (:foreground ,base01 :slant italic))))
      `(org-archived ((,class (:foreground ,base01 :weight normal))))
      `(org-block ((,class (:foreground ,base01))))
-     `(org-block-begin-line ((,class (:foreground ,base01 :slant italic))))
      `(org-checkbox ((,class (:background ,base03 :foreground ,base0
                                           :box (:line-width 1 :style released-button)))))
      `(org-code ((,class (:foreground ,base01))))
@@ -1641,6 +1640,7 @@ customize the resulting theme."
      `(org-level-8 ((,class (:inherit ,s-variable-pitch
                                       :foreground ,blue))))
      `(org-link ((,class (:foreground ,yellow :underline t))))
+     `(org-meta-line ((,class (:foreground ,base01 :slant italic))))
      `(org-sexp-date ((,class (:foreground ,violet))))
      `(org-scheduled ((,class (:foreground ,green))))
      `(org-scheduled-previously ((,class (:foreground ,cyan))))


### PR DESCRIPTION
Previously discussed at https://github.com/bbatsov/solarized-emacs/pull/258

I've upgraded Org to 9.0.5 and confirmed that this fix is needed.  Thanks.