### PR TITLE
solarized.el: Set indent of solarized-with-color-variables

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -134,7 +134,7 @@ Alpha should be a float between 0 and 1."
 
 ;;; Setup Start
 (defmacro solarized-with-color-variables (variant &rest body)
-  (declare (indent 0))
+  (declare (indent defun))
   `(let* ((class '((class color) (min-colors 89)))
          (variant ,variant)
          (s-base03    "#002b36")


### PR DESCRIPTION
This adjusts the indentation of the macro so that uses of it are indented like normal macros.  

It might be a good idea to reindent the source files after this in another commit.  Let me know if you'd like me to do this.

Thanks.