### PR TITLE
Update git-commit faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -867,7 +867,12 @@ customize the resulting theme."
         (,class (:foreground ,red :weight bold :underline t))))
 ;;;;; git-commit
      `(git-commit-comment-action  ((,class (:foreground ,base0  :weight bold))))
-     `(git-commit-comment-branch  ((,class (:foreground ,blue   :weight bold))))
+     `(git-commit-comment-branch ; obsolete
+       ((,class (:foreground ,blue :weight bold))))
+     `(git-commit-comment-branch-local
+       ((,class (:foreground ,blue :weight bold))))
+     `(git-commit-comment-branch-remote
+       ((,class (:foreground ,green :weight bold))))
      `(git-commit-comment-heading ((,class (:foreground ,yellow :weight bold))))
 ;;;;; git-gutter
      `(git-gutter:added


### PR DESCRIPTION
```
The old face `git-commit-comment-branch' was replaced
with two new faces `git-commit-comment-branch-local'
and `git-commit-comment-branch-remote'.

Keep the old face around for a while until "everyone"
has updated, but at least until the next `git-commit'
release.
```