### PR TITLE
Fix #194 Unified diff diff-hl ediff and smerge faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -613,118 +613,45 @@ customize the resulting theme."
      `(custom-button-unraised ((,class (:inherit underline))))
      `(custom-button-pressed-unraised ((,class (:inherit custom-button-unraised :foreground ,magenta))))
 ;;;;; diff
-     `(diff-added   ((,class (:foreground ,green))))
-     `(diff-changed ((,class (:foreground ,blue))))
-     `(diff-removed ((,class (:foreground ,red))))
-     `(diff-refine-added
-       ((,light-class
-         (:background ,(solarized-color-blend "#ddffdd" green 0.7)))
-        (,dark-class
-         (:background ,(solarized-color-blend "#446644" green 0.7)))))
-     `(diff-refine-changed
-       ((,light-class
-         (:background ,(solarized-color-blend "#ddddff" blue 0.7)))
-        (,dark-class
-         (:background ,(solarized-color-blend "#444466" blue 0.7)))))
-     `(diff-refine-removed
-       ((,light-class
-         (:background ,(solarized-color-blend "#ffdddd" red 0.7)))
-        (,dark-class
-         (:background ,(solarized-color-blend "#664444" red 0.7)))))
+     `(diff-added ((,class (:background ,green-lc :foreground ,base3 :weight normal :slant normal))))
+     `(diff-changed ((,class (:background ,yellow-lc :foreground ,base3 :weight normal :slant normal))))
+     `(diff-removed ((,class (:background ,orange-lc :foreground ,base3 :weight normal :slant normal))))
+     `(diff-refine-added ((,class (:foreground ,green-hc :underline t))))
+     `(diff-refine-changed ((,class (:foreground ,yellow-hc :underline t))))
+     `(diff-refine-removed ((,class (:foreground ,orange-hc :underline t))))
      `(diff-header  ((,class (:background ,base03))))
      `(diff-file-header
        ((,class (:background ,base03 :foreground ,base0 :weight bold))))
 ;;;;; diff-hl
-     `(diff-hl-change ((,class (:background ,blue-lc  :foreground ,blue-hc))))
-     `(diff-hl-delete ((,class (:background ,red-lc  :foreground ,red-hc))))
-     `(diff-hl-insert ((,class (:background ,green-lc  :foreground ,green-hc))))
-     `(diff-hl-unknown ((,class (:background ,cyan-lc   :foreground ,cyan-hc))))
+     `(diff-hl-change ((,class (:background ,blue-lc :foreground ,blue-hc))))
+     `(diff-hl-delete ((,class (:background ,orange-lc :foreground ,orange-hc))))
+     `(diff-hl-insert ((,class (:background ,green-lc :foreground ,green-hc))))
+     `(diff-hl-unknown ((,class (:background ,yellow-lc :foreground ,yellow-hc))))
 ;;;;; ediff
-     `(ediff-fine-diff-A ((,class (:background ,orange-lc))))
-     `(ediff-fine-diff-B ((,class (:background ,green-lc))))
-     `(ediff-fine-diff-C ((,class (:background ,yellow-lc))))
-
-     `(ediff-current-diff-C ((,class (:background ,blue-lc))))
-
-     `(ediff-even-diff-A ((,class (:background ,base01
-                                               :foreground ,base3 ))))
-     `(ediff-odd-diff-A ((,class (:background ,base01
-                                              :foreground ,base03 ))))
-     `(ediff-even-diff-B ((,class (:background ,base01
-                                               :foreground ,base03 ))))
-     `(ediff-odd-diff-B ((,class (:background ,base01
-                                              :foreground ,base03 ))))
-     `(ediff-even-diff-C ((,class (:background ,base01
-                                               :foreground ,base0 ))))
-     `(ediff-odd-diff-C ((,class (:background ,base01
-                                              :foreground ,base03 ))))
-
-;;;;;; alternative ediff (not finished)
-     ;; `(ediff-fine-diff-A ((,class (
-     ;;                               :background ,(solarized-color-blend blue base03 0.25))
-     ;;                              )))
-     ;; `(ediff-fine-diff-B ((,class (
-     ;;                               :background ,(solarized-color-blend violet base03 0.25))
-     ;;                              )))
-     ;; `(ediff-fine-diff-C ((,class (
-     ;;                               :background ,(solarized-color-blend yellow base03 0.25))
-     ;;                              )))
-     ;; `(ediff-current-diff-A ((,class (
-     ;;                                  :background ,(solarized-color-blend blue base03 0.15)
-     ;;                                              ))))
-     ;; `(ediff-current-diff-B ((,class (
-     ;;                                   :background ,(solarized-color-blend violet base03 0.15)
-     ;;                                              ))))
-     ;; `(ediff-current-diff-C ((,class (
-     ;;                                  :background ,(solarized-color-blend yellow base03 0.15)
-     ;;                                              ))))
-     ;; `(ediff-even-diff-A ((,class (
-     ;;                                ;; :background ,(solarized-color-blend base0 base03 0.15)
-     ;;                               :background ,base02
-     ;;                               ;; :foreground ,base2
-     ;;                                ;; :background ,(solarized-color-blend green base02 0.15)
-     ;;                                           ))))
-     ;; `(ediff-even-diff-B ((,class (
-     ;;                               ;; :background ,base01
-     ;;                               :background ,base02
-     ;;                               ;; :foreground ,base2
-     ;;                                           ))))
-     ;; `(ediff-even-diff-C ((,class (
-     ;;                               ;; :background ,base01
-     ;;                               :background ,base02
-     ;;                                           ;; :foreground ,base2
-     ;;                                           ))))
-     ;; `(ediff-odd-diff-A ((,class (
-     ;;                              ;; :background ,base01
-     ;;                                          :background ,base02
-     ;;                                          ))))
-     ;; `(ediff-odd-diff-B ((,class (
-     ;;                              ;; :background ,base01
-     ;;                                          :background ,base02
-     ;;                                          ))))
-     ;; `(ediff-odd-diff-C ((,class (
-     ;;                              ;; :background ,base01
-     ;;                                          :background ,base03
-     ;;                                          ))))
-     ;; `(ediff-current-diff-Ancestor ((,class (:background "VioletRed" :foreground "Black"))))
-     ;; `(ediff-even-diff-Ancestor ((,class (:background "Grey" :foreground "White"))))
-     ;; `(ediff-fine-diff-Ancestor ((,class (:background "Green" :foreground "Black"))))
-     ;; `(ediff-odd-diff-Ancestor ((,class (:background "gray40" :foreground "cyan3"))))
-     ;; `(ediff-even-diff-A ((,class (:underline ,base01))))
-     ;; `(ediff-odd-diff-A ((,class (:underline ,base01
-     ;;                                          ))))
-     ;; `(ediff-even-diff-B ((,class (:background ,base01
-     ;;                                           :foreground ,base03
-     ;;                                           ))))
-     ;; `(ediff-odd-diff-B ((,class (:background ,base01
-     ;;                                          :foreground ,base03
-     ;;                                          ))))
-     ;; `(ediff-even-diff-C ((,class (:background ,base01
-     ;;                                           :foreground ,base0
-     ;;                                           ))))
-     ;; `(ediff-odd-diff-C ((,class (:background ,base01
-     ;;                                          :foreground ,base03
-     ;;                                          ))))
+     `(ediff-fine-diff-A ((,class (:foreground ,orange-hc :underline t))))
+     `(ediff-fine-diff-B ((,class (:foreground ,green-hc :underline t))))
+     `(ediff-fine-diff-C ((,class (:foreground ,cyan-hc :underline t))))
+     `(ediff-fine-diff-Ancestor ((,class (:background ,green))))
+     `(ediff-current-diff-A ((,class (:background ,orange-lc :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-current-diff-B ((,class (:background ,green-lc :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-current-diff-C ((,class (:background ,cyan-lc :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-current-diff-Ancestor ((,class (:background ,magenta :weight normal :slant normal))))
+     `(ediff-even-diff-A ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-even-diff-B ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-even-diff-C ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-even-diff-Ancestor ((,class (:background ,(color-lighten-name base02 0.5) :weight normal :slant normal))))
+     `(ediff-odd-diff-A ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-odd-diff-B ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-odd-diff-C ((,class (:background ,base02 :foreground ,base3 :weight normal :slant normal))))
+     `(ediff-odd-diff-Ancestor ((,class (:background ,(color-lighten-name base02 0.5) :weight normal :slant normal))))
+;;;;;; smerge
+     `(smerge-markers ((,class (:background ,base02))))
+     `(smerge-base ((,class (:background ,yellow-lc :foreground ,base3 :weight normal :slant normal))))
+     `(smerge-mine ((,class (:background ,green-lc :foreground ,base3 :weight normal :slant normal))))
+     `(smerge-other ((,class (:background ,orange-lc :foreground ,base3 :weight normal :slant normal))))
+     `(smerge-refined-added ((,class (:foreground ,green-hc :underline t))))
+     `(smerge-refined-changed ((,class (:background ,blue-lc :foreground ,cyan-hc :underline t))))
+     `(smerge-refined-removed ((,class (:foreground ,orange-hc :underline t))))
 ;;;;; edts
      `(edts-face-error-line
        ((,(append '((supports :underline (:style line))) light-class)


### PR DESCRIPTION
This should fix #192 and #134. In this PR I've unified the colors as much as I could. Some modes have extra faces for changed blocks, in contexts where there are only 2 major color values (red and green), I've used yellow to indicate changes. When there's more, I've used blue-lc background and cyan-hc foreground to make the text more legible.

When outside of changed blocks (added and deleted), the foreground is highlighted with a slightly higher contrast color (base3), for legibility again. Font locking weights and slants are removed in all hunks to improved legibility.

For diff and ediff, refined blocks are highlighted by using the high contrast version of the background color on the foreground. They are underlined too.

For ediff and smerge, anything other than the hunks are only subtlely highlighted to minimize distraction.

Oh, did I mention there's smerge theme now? Merry Christmas!

<img width="1440" alt="screen shot 2017-12-25 at 20 02 28" src="https://user-images.githubusercontent.com/160028/34343085-f66ceb9a-e9bb-11e7-92ce-3205482ba1f9.png">
<img width="1440" alt="screen shot 2017-12-25 at 20 03 02" src="https://user-images.githubusercontent.com/160028/34343087-f67fdc3c-e9bb-11e7-9a83-b02a5fba515a.png">
<img width="1440" alt="screen shot 2017-12-25 at 20 05 36" src="https://user-images.githubusercontent.com/160028/34343088-f6926960-e9bb-11e7-9c80-5a9723c3aaf1.png">
<img width="1440" alt="screen shot 2017-12-25 at 20 06 18" src="https://user-images.githubusercontent.com/160028/34343089-f6a86436-e9bb-11e7-8c97-8e2120c7eca7.png">
<img width="1440" alt="screen shot 2017-12-25 at 21 26 53" src="https://user-images.githubusercontent.com/160028/34343090-f6bb1b26-e9bb-11e7-9ba7-a2291c523de3.png">
<img width="1440" alt="screen shot 2017-12-25 at 21 28 31" src="https://user-images.githubusercontent.com/160028/34343091-f6cdbcb8-e9bb-11e7-86d3-f536af3c2337.png">
