### PR TITLE
small fix for solarized-dark theme

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -367,7 +367,7 @@ customize the resulting theme."
      `(dired-async-message ((,light-class (:background ,yellow-l ))
                             (,dark-class (:background ,yellow ))))
      `(dired-async-mode-message ((,light-class (:background ,red-l))
-                                 (,dark-class (:background red))))
+                                 (,dark-class (:background ,red))))
 ;;;;; dired-efap
      `(dired-efap-face ((,class (:box nil
                                       :background ,base02


### PR DESCRIPTION
Without the leading comma, emacs will report a error on `dired-async-message` for a mismatched type error `stringp red`.

Tested locally on Emacs 25.2.1, macOS.