### PR TITLE
Add macrostep face

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1328,6 +1328,8 @@ customize the resulting theme."
      `(lusty-file-face ((,class nil)))
      `(lusty-match-face ((,class (:inherit ido-first-match))))
      `(lusty-slash-face ((,class (:foreground ,cyan :weight bold))))
+;;;;; macrostep
+     `(macrostep-expansion-highlight-face ((,class (:background ,base02))))
 ;;;;; magit
 ;;;;;; headings and diffs
      `(magit-section-highlight           ((t (:background ,base02))))


### PR DESCRIPTION
This face determines the background of a expanded macro.

Before:
![screen shot 2018-03-01 at 10 03 49 pm](https://user-images.githubusercontent.com/2208382/36881608-fcc14f8a-1d9c-11e8-97fb-f8ec31e29a2d.png)

After:
![screen shot 2018-03-01 at 10 04 36 pm](https://user-images.githubusercontent.com/2208382/36881610-fee8045c-1d9c-11e8-8d09-aca3488a7dd4.png)
