### PR TITLE
Add faces for langtool

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1348,6 +1348,11 @@ customize the resulting theme."
      `(kite-tag-delimiter-face ((,class (:inherit kite-delimiter-face))))
      `(kite-tag-slash-face ((,class (:inherit kite-name-face))))
      `(kite-undefined ((,class (:inherit font-lock-constant-face))))
+;;;;; langtool
+     `(langtool-errline ((,(append '((supports :underline (:style wave))) class)
+                          (:underline (:style wave :color ,green) :inherit unspecified))
+                         (,class (:foreground ,red :weight bold :underline t))))
+     `(langtool-correction-face ((,class (:inherit default :weight bold))))
 ;;;;; ledger-mode
      `(ledger-font-payee-uncleared-face ((t (:foreground ,red))))
      `(ledger-font-payee-cleared-face ((t (:foreground ,green :weight normal))))


### PR DESCRIPTION
Two faces. 
1. `langtool-errline` for marking errors. I chose a green wavy line, which is common for marking grammar errors (which is mostly the task of languagetool, although it also does spelling correction) in other programs. In the case of no wavy lines let it have red foreground with underline, since green text doesn’t commonly signify an error.
2. `langtool-correction-face` for displaying suggested corrections ("many" in the screenshot). It is defined as rather sharp (yellow and bold on red) in `langtool.el` but I saw no need for that and think that bold sets it off clear enough.

![screenshot](https://user-images.githubusercontent.com/846411/41532474-6a3607f4-72f7-11e8-819b-3b4c4ded5758.png)
