### PR TITLE
Use thin font for linum and display-line-number when available

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1366,10 +1366,10 @@ customize the resulting theme."
      `(ledger-font-reconciler-pending-face ((t (:foreground ,yellow :weight normal))))
      `(ledger-font-report-clickable-face ((t (:foreground ,yellow :weight normal))))
 ;;;;; linum-mode
-     `(linum ((,class (:weight normal :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
+     `(linum ((,class (:weight thin :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
      `(linum-relative-current-face ((,class (:inherit linum))))
 ;;;;; display-line-number-mode
-     `(line-number ((,class (:weight normal :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
+     `(line-number ((,class (:weight thin :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
 ;;;;; lsp-ui
      `(lsp-ui-sideline-code-action ((,class (:foreground ,yellow :weight normal))))
 ;;;;; lusty-explorer


### PR DESCRIPTION
If the default font the user is using doesn't have a thin weight, this change does nothing. Otherwise, it will use the thin variant of the font. Line numbers are ancillary information, but it's always in your face. It's useful sometimes but distracting if steals focus away from the reader when scanning a line from left to right. 

## Before
<img width="555" alt="screen shot 2018-06-20 at 16 10 45" src="https://user-images.githubusercontent.com/160028/41667310-87aa2aaa-74a4-11e8-90bd-79f14f1f56c3.png">


## After
<img width="498" alt="screen shot 2018-06-20 at 16 05 33" src="https://user-images.githubusercontent.com/160028/41667043-e5147872-74a3-11e8-8e84-b6e94427d511.png">

