### PR TITLE
Add org-macro

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1724,6 +1724,7 @@ customize the resulting theme."
                                       :foreground ,blue))))
      `(org-link ((,class (:foreground ,yellow :underline t))))
      `(org-meta-line ((,class (:foreground ,base01 :slant italic))))
+     `(org-macro ((,class (:foreground ,s-base1))))
      `(org-sexp-date ((,class (:foreground ,violet))))
      `(org-scheduled ((,class (:foreground ,green))))
      `(org-scheduled-previously ((,class (:foreground ,cyan))))


### PR DESCRIPTION
Adds org-macro, defining it slightly (one step) brighter than the normal text: noticeable, without interrupting the flow with a color.