### PR TITLE
Underline current match in Ivy

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1224,7 +1224,7 @@ customize the resulting theme."
        ((,class (:foreground ,orange :background ,base02))))
 ;;;;; ivy
      `(ivy-confirm-face ((,class (:foreground ,green))))
-     `(ivy-current-match ((,class (:weight bold :background ,base02))))
+     `(ivy-current-match ((,class (:weight bold :background ,base02 :underline t))))
      `(ivy-match-required-face ((,class (:foreground ,red))))
      `(ivy-minibuffer-match-face-1 ((,class (:foreground ,base1))))
      `(ivy-minibuffer-match-face-2 ((,class (:foreground ,yellow))))


### PR DESCRIPTION
`ivy-current-match` is too hard to see when using `C-h v` since some of the matches are already highlighted. This change simply underlines the current match, making it easy to distinguish.

Before:
![solarized_default](https://user-images.githubusercontent.com/5191426/44943023-3b501000-adc7-11e8-9c6e-c1f568c24d54.png)
After:
![solarized_edited](https://user-images.githubusercontent.com/5191426/44943024-3b501000-adc7-11e8-8762-9ad2bdb92089.png)
