### PR TITLE
Theme outline-minor-faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1782,6 +1782,11 @@ customize the resulting theme."
      `(outline-6 ((,class (:inherit ,s-variable-pitch :foreground ,green))))
      `(outline-7 ((,class (:inherit ,s-variable-pitch :foreground ,red))))
      `(outline-8 ((,class (:inherit ,s-variable-pitch :foreground ,blue))))
+;;;;; outline-minor-faces
+     `(outline-minor-0 ((,class (:weight bold :background ,s-base2))))
+     `(outline-minor-1
+       ((,class (:inherit (outline-minor-0 outline-1)
+                 :background ,(solarized-color-blend s-base3 yellow .9)))))
 ;;;;; paren-face
      `(paren-face  ((,class (:foreground ,base01))))
 ;;;;; perspective


### PR DESCRIPTION
Unlike `outline-mode`, `outline-minor-mode` does not change
the appearance of headings to look different from comments.

The `outline-minor-faces` package defined faces `outline-minor-N`,
which inherit from the respective `outline-N` faces and arranges
for them to be used in `outline-minor-mode`.

* https://github.com/tarsius/outline-minor-faces
* https://github.com/tarsius/backline might also be of interest. It makes sure that the background color of the heading "extends all the way to the right edge of the window" even when the section body is collapsed.