### PR TITLE
Fix #231: Change cider-deprecated-face to yellow underline instead of background

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -594,7 +594,7 @@ customize the resulting theme."
      `(cider-result-overlay-face ((t (:background unspecified))))
      `(cider-enlightened-face ((t (:box (:color ,magenta :line-width -1)))))
      `(cider-enlightened-local-face ((t (:weight bold :foreground ,green-l))))
-     `(cider-deprecated-face ((t (:background ,yellow))))
+     `(cider-deprecated-face ((t (:underline (:color ,yellow)))))
      `(cider-instrumented-face ((t (:box (:color ,red-l :line-width -1)))))
      `(cider-traced-face ((t (:box (:color ,cyan :line-width -1)))))
      `(cider-fringe-good-face ((t (:foreground ,green-l))))


### PR DESCRIPTION
This PR fixes #231 by changing the yellow background of the `cider-deprecated-face` to a yellow underline:

![afbeelding](https://user-images.githubusercontent.com/8885691/51992442-4cec2f80-24ad-11e9-8f15-ca9c06da0004.png)
