### PR TITLE
Theme some more transient faces

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -2069,6 +2069,10 @@ customize the resulting theme."
      `(transient-disabled-suffix     ((t (:foreground ,s-base3
                                           :background ,red
                                           :weight bold))))
+     `(transient-nonstandard-key
+       ((t (:underline nil :background ,(solarized-color-blend yellow-l s-base3 0.2)))))
+     `(transient-mismatched-key
+       ((t (:underline nil :background ,(solarized-color-blend red-l s-base3 0.2)))))
 ;;;;; tuareg
      `(tuareg-font-lock-governing-face ((,class (:foreground ,magenta :weight bold))))
      `(tuareg-font-lock-multistage-face ((,class (:foreground ,blue :background ,base02


### PR DESCRIPTION
Well I though I was done when I opened the last pr but it turned out we need two more faces... Those should be the last ones; I don't think I will add any new ones before I release on Wednesday or so.  I hope ;-)

A note on why these faces are "dimmed" so much.  These faces are used for key bindings (e.g. "-f") for infix arguments (e.g. "--force-with-lease") that do *not* correspond to the respective short argument (e.g. "-f", which in this case actually is short for the much more dangerous "--force").  Highlighting such keys is useful when working on making as many bindings consistent as possible but also when "learning git by using magit".  There are quite a few inconsistent bindings so it shouldn't be in your face.