### PR TITLE
Remove org-block-begin-line and org-block-end-line

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -1696,8 +1696,6 @@ customize the resulting theme."
      `(org-agenda-done ((,class (:foreground ,base01 :slant italic))))
      `(org-archived ((,class (:foreground ,base01 :weight normal))))
      `(org-block ((,class nil)))
-     `(org-block-begin-line ((,class (:inherit org-meta-line :underline t))))
-     `(org-block-end-line ((,class (:inherit org-meta-line :overline t))))
      `(org-checkbox ((,class (:background ,base03 :foreground ,base0
                                           :box (:line-width 1 :style released-button)))))
      `(org-code ((,class (:foreground ,base01))))


### PR DESCRIPTION
They violate the principle of least astonishment because:

- The default theme doesn't underline them. Other elements are
  underlined dates, links, and footnotes. But source block begin
  and end lines are not underlined so they should not be here.
- The underline is a jarring interruption of the flow
- The Solarized theme doesn't suggest underlines to begin with so
  adding them here is too divergent from what anyone would expect.