### PR TITLE
Theme display-fill-column-indicator'

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -381,6 +381,8 @@ customize the resulting theme."
                                       :foreground ,base1
                                       :underline ,s-line
                                       :weight bold))))
+;;;;; display-fill-column-indicator
+     `(fill-column-indicator ((,class :foreground ,base02 :weight semilight)))
 ;;;;; dropdown
      `(dropdown-list-face ((,class (:background ,base02 :foreground ,cyan))))
      `(dropdown-list-selection-face ((,class (:background ,cyan-lc :foreground ,cyan-hc))))


### PR DESCRIPTION
`display-fill-column-indicator` is a new built-in package added in
Emacs 27 intended as a replacement for the third-party package
`fill-column-indicator`.  The former is much faster and the latter is
no longer maintained.

The face `fill-column-indicator` is used by the package
`display-fill-column-indicator`, and NOT by the package
`fill-column-indicator` as one might expect.  (All functions and faces
used by `fill-column-indicator` are prefixed with `fci-`, and it has
no faces).

Using a weight of `semilight` makes the indicator a lot thinner than
the default, which is `normal`.  But it is not as thin as what this
theme currently used for the indicator that is drawn by the
`fill-column-indicator` package by setting `fci-rule-width` to 1
(pixel).  For that a value of `thin` would have to be used, but
I find that too thin, considering that we additionally use a color
that is very close to the background color.