### PR TITLE
Fix package-lint warnings/error

### DIFF
--- a/child-theme-example/themes/my-solarized-dark-theme.el
+++ b/child-theme-example/themes/my-solarized-dark-theme.el
@@ -4,6 +4,6 @@
 ;; This files needs to be places iside the custom-theme-load-path list
 
 (deftheme my-solarized-dark "The dark variant of the Solarized colour theme")
-(create-solarized-theme 'dark 'my-solarized-dark 'my-solarized-theme)
+(solarized-create-theme 'dark 'my-solarized-dark 'my-solarized-theme)
 
 (provide-theme 'my-solarized-dark)

--- a/child-theme-example/themes/my-solarized-light-theme.el
+++ b/child-theme-example/themes/my-solarized-light-theme.el
@@ -4,6 +4,6 @@
 ;; This files needs to be places iside the custom-theme-load-path list
 
 (deftheme my-solarized-light "The light variant of the Solarized colour theme")
-(create-solarized-theme 'light 'my-solarized-light 'my-solarized-theme)
+(solarized-create-theme 'light 'my-solarized-light 'my-solarized-theme)
 
 (provide-theme 'my-solarized-light)

--- a/solarized-dark-theme.el
+++ b/solarized-dark-theme.el
@@ -25,7 +25,7 @@
 
 (deftheme solarized-dark "The dark variant of the Solarized colour theme")
 
-(create-solarized-theme 'dark 'solarized-dark)
+(solarized-create-theme 'dark 'solarized-dark)
 
 (provide-theme 'solarized-dark)
 

--- a/solarized-light-theme.el
+++ b/solarized-light-theme.el
@@ -25,7 +25,7 @@
 
 (deftheme solarized-light "The light variant of the Solarized colour theme")
 
-(create-solarized-theme 'light 'solarized-light)
+(solarized-create-theme 'light 'solarized-light)
 
 (provide-theme 'solarized-light)
 

--- a/solarized-wombat-dark-theme.el
+++ b/solarized-wombat-dark-theme.el
@@ -25,7 +25,7 @@
 
 (deftheme solarized-wombat-dark "The the dark solarized theme with the wombat palette")
 
-(create-solarized-theme-with-palette 'dark 'solarized-wombat-dark
+(solarized-create-theme-with-palette 'dark 'solarized-wombat-dark
   '("#2a2a29" "#f6f3e8"           ; base03 (02 01 00 0 1 2) base3
     "#e5c06d" "#ddaa6f"           ; yellow orange
     "#ffb4ac" "#e5786d"           ; red    magenta

--- a/solarized.el
+++ b/solarized.el
@@ -248,6 +248,8 @@ The Returned color-palette has the same format as `solarized-color-palette'"
 
 ;;; Setup Start
 (defmacro solarized-with-color-variables (variant color-palette &rest body)
+  "Eval BODY in solarized COLOR-PALETTE.
+VARIANT is 'dark or 'light."
   (declare (indent defun))
   `(let* ((class '((class color) (min-colors 89)))
           (light-class (append '((background light)) class))
@@ -367,13 +369,13 @@ customize the resulting theme."
 When optional argument CHILDTHEME function is supplied it's invoked to further
 customize the resulting theme.
 
-CORE-PALETTE is core color-palette, passed"
+CORE-PALETTE is core color-palette."
   (declare (indent 2))
   (let ((color-palette (solarized-create-color-palette core-palette)))
     (solarized-definition variant theme-name color-palette childtheme)))
 
 (defun solarized-definition (variant theme-name color-palette &optional childtheme)
-  "Create a VARIANT of the theme named THEME-NAME.
+  "Create a VARIANT of the theme named THEME-NAME with COLOR-PALETTE.
 
 When optional argument CHILDTHEME function is supplied it's invoked to further
 customize the resulting theme."

--- a/solarized.el
+++ b/solarized.el
@@ -323,8 +323,7 @@ The Returned color-palette has the same format as `solarized-color-palette'"
           (s-mode-line-inactive-bg (if solarized-high-contrast-mode-line
                                        base02 base03))
           (s-mode-line-inactive-bc (if solarized-high-contrast-mode-line
-                                       base02 base02))
-          )
+                                       base02 base02)))
      ,@body))
 
 (defun create-solarized-theme-file (variant theme-name core-palette &optional childtheme overwrite)
@@ -1069,26 +1068,22 @@ customize the resulting theme."
          ((,class (:weight normal
                            :foreground ,(if solarized-emphasize-indicators
                                             green s-fringe-fg)
-                           :background ,s-fringe-bg
-                           ))))
+                           :background ,s-fringe-bg))))
        `(git-gutter:deleted
          ((,class (:weight normal
                            :foreground ,(if solarized-emphasize-indicators
                                             red s-fringe-fg)
-                           :background ,s-fringe-bg
-                           ))))
+                           :background ,s-fringe-bg))))
        `(git-gutter:modified
          ((,class (:weight normal
                            :foreground ,(if solarized-emphasize-indicators
                                             blue s-fringe-fg)
-                           :background ,s-fringe-bg
-                           ))))
+                           :background ,s-fringe-bg))))
        `(git-gutter:unchanged
          ((,class (:weight normal
                            :foreground ,(if solarized-emphasize-indicators
                                             base01 s-fringe-fg)
-                           :background ,s-fringe-bg
-                           ))))
+                           :background ,s-fringe-bg))))
 ;;;;; git-gutter-fr
        `(git-gutter-fr:added ((,class (:foreground ,green  :weight bold))))
        `(git-gutter-fr:deleted ((,class (:foreground ,red :weight bold))))
@@ -2412,8 +2407,7 @@ customize the resulting theme."
        `(ztreep-expand-sign-face ((,class (:foreground ,base01))))
        `(ztreep-header-face ((,class (:foreground ,base01 :weight bold :height 1.2))))
        `(ztreep-leaf-face ((,class (:foreground  ,base0))))
-       `(ztreep-node-face ((,class (:foreground ,blue))))
-       ) ; END custom-theme-set-faces
+       `(ztreep-node-face ((,class (:foreground ,blue)))))
 ;;; Theme Variables
       (custom-theme-set-variables
        ',theme-name
@@ -2499,10 +2493,7 @@ customize the resulting theme."
                                            ,base0 ,violet ,base1 ,base3]))
 ;;; Setup End
       ,(when childtheme
-         `(funcall ',childtheme))
-      ) ; END custom-theme-set-variables
-   )
-  )    ; END defun create-solarized-theme
+         `(funcall ',childtheme)))))
 
 ;;; Footer
 

--- a/solarized.el
+++ b/solarized.el
@@ -328,7 +328,7 @@ VARIANT is 'dark or 'light."
                                        base02 base02)))
      ,@body))
 
-(defun create-solarized-theme-file (variant theme-name core-palette &optional childtheme overwrite)
+(defun solarized-create-theme-file (variant theme-name core-palette &optional childtheme overwrite)
   "Create a VARIANT of the theme named THEME-NAME with CORE-PALETTE.
 
 When optional argument CHILDTHEME function is supplied it's invoked to further
@@ -351,19 +351,19 @@ If OVERWRITE is non-nil, overwrite theme file if exist."
                 (deftheme ,theme-name
                   ,(format "The %s colour theme of Solarized colour theme flavor." theme-name))
                 (let ((custom--inhibit-theme-enable nil))
-                  (create-solarized-theme-with-palette ',variant ',theme-name ',core-palette ',childtheme))
+                  (solarized-create-theme-with-palette ',variant ',theme-name ',core-palette ',childtheme))
                 (provide-theme ',theme-name)
                 (provide ',(intern (format "%s-theme" theme-name)))))))
     path))
 
-(defun create-solarized-theme (variant theme-name &optional childtheme)
+(defun solarized-create-theme (variant theme-name &optional childtheme)
   "Create a VARIANT of the theme named THEME-NAME.
 
 When optional argument CHILDTHEME function is supplied it's invoked to further
 customize the resulting theme."
   (solarized-definition variant theme-name solarized-color-palette-alist childtheme))
 
-(defun create-solarized-theme-with-palette (variant theme-name core-palette &optional childtheme)
+(defun solarized-create-theme-with-palette (variant theme-name core-palette &optional childtheme)
   "Create a VARIANT of the theme named THEME-NAME with CORE-PALETTE.
 
 When optional argument CHILDTHEME function is supplied it's invoked to further
@@ -373,6 +373,10 @@ CORE-PALETTE is core color-palette."
   (declare (indent 2))
   (let ((color-palette (solarized-create-color-palette core-palette)))
     (solarized-definition variant theme-name color-palette childtheme)))
+
+(define-obsolete-function-alias create-solarized-theme-file         solarized-create-theme-file)
+(define-obsolete-function-alias create-solarized-theme              solarized-create-theme)
+(define-obsolete-function-alias create-solarized-theme-with-palette solarized-create-theme-with-palette)
 
 (defun solarized-definition (variant theme-name color-palette &optional childtheme)
   "Create a VARIANT of the theme named THEME-NAME with COLOR-PALETTE.

--- a/solarized.el
+++ b/solarized.el
@@ -1,4 +1,4 @@
-;;; solarized.el --- Solarized for Emacs.
+;;; solarized.el --- Solarized theme
 
 ;; Copyright (C) 2011-2019 Bozhidar Batsov
 

--- a/solarized.el
+++ b/solarized.el
@@ -7,7 +7,7 @@
 ;; URL: http://github.com/bbatsov/solarized-emacs
 ;; Version: 1.3.0
 ;; Package-Requires: ((emacs "24") (dash "2.16"))
-;; Keywords: themes, solarized
+;; Keywords: convenience, themes, solarized
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/solarized.el
+++ b/solarized.el
@@ -6,7 +6,7 @@
 ;; Author: Thomas Frössman <thomasf@jossystem.se>
 ;; URL: http://github.com/bbatsov/solarized-emacs
 ;; Version: 1.3.0
-;; Package-Requires: ((emacs "24") (dash "2.16"))
+;; Package-Requires: ((emacs "24.1") (dash "2.16"))
 ;; Keywords: convenience, themes, solarized
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Hi!
I fix all warnings/error listed as below via pakage-lint.

``` emacs-lisp
 solarize…     1   1 warning         Including "Emacs" in the package summary is usually redundant. (emacs-lisp-package)
 solarize…    10   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 solariz…    45  11 error           You should depend on (emacs "24.1") if you need `color'. (emacs-lisp-package)
 solariz…   147  26 error           You should depend on (emacs "24.1") if you need `color-name-to-rgb'. (emacs-lisp-package)
 solariz…   148  26 error           You should depend on (emacs "24.1") if you need `color-name-to-rgb'. (emacs-lisp-package)
 solariz…   251     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 solariz…   327  11 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solariz…   330   1 error           "create-solarized-theme-file" doesn't start with package's prefix "solarized". (emacs-lisp-package)
 solariz…   358   1 error           "create-solarized-theme" doesn't start with package's prefix "solarized". (emacs-lisp-package)
 solariz…   365   1 error           "create-solarized-theme-with-palette" doesn't start with package's prefix "solarized". (emacs-lisp-package)
 solari…   377     warning         Argument ‘color-palette’ should appear (as COLOR-PALETTE) in the doc string (emacs-lisp-checkdoc)
 solari…  1073  28 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  1079  28 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  1085  28 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  1091  28 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  1826  10 error           You should depend on (emacs "24.1") if you need `org-block'. (emacs-lisp-package)
 solari…  1832  10 error           You should depend on (emacs "24.1") if you need `org-date'. (emacs-lisp-package)
 solari…  2416   8 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  2503   7 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 solari…  2505   3 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
```