### PR TITLE
Remove turning on rainbow-mode magic comment

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -2515,7 +2515,6 @@ customize the resulting theme."
 
 ;; Local Variables:
 ;; no-byte-compile: t
-;; eval: (when (fboundp 'rainbow-mode) (rainbow-mode 1))
 ;; indent-tabs-mode: nil
 ;; fill-column: 95
 ;; End:


### PR DESCRIPTION
rainbow-mode is very useful but whether turn on or off
is the decision of the developer.
Pop up execute magic comment every and every time is
very tired.