### PR TITLE
Include pkg file information into solarized-theme.el

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1,6 +1,26 @@
 ;;; solarized-faces.el --- the faces definitions for solarized theme
 
-;; see solarized.el header for general package information.
+;; Copyright (C) 2011-2019 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.com>
+;; Author: Thomas Frössman <thomasf@jossystem.se>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; the faces definitions for solarized theme
 
 ;;; Code:
 

--- a/solarized-palettes.el
+++ b/solarized-palettes.el
@@ -1,6 +1,22 @@
 ;;; solarized-palettes.el
 
-;; see solarized.el for general package header information
+;; Copyright (C) 2011-2019 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.com>
+;; Author: Thomas Frössman <thomasf@jossystem.se>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/solarized-theme-pkg.el
+++ b/solarized-theme-pkg.el
@@ -1,5 +1,0 @@
-(define-package
-  "solarized-theme"
-  "1.2.2"
-  "The Solarized color theme, ported to Emacs."
-  '((emacs "24.1") (cl-lib "0.5") (dash "2.6.0")))

--- a/solarized-theme.el
+++ b/solarized-theme.el
@@ -1,2 +1,47 @@
+;;; solarized-theme.el --- The Solarized color theme
+
+;; Copyright (C) 2011-2019 Bozhidar Batsov
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.com>
+;; Author: Thomas Frössman <thomasf@jossystem.se>
+;; URL: http://github.com/bbatsov/solarized-emacs
+;; Version: 1.3.0
+;; Package-Requires: ((emacs "24.1") (dash "2.16"))
+;; Keywords: convenience, themes, solarized
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; A port of Solarized to Emacs.
+;;
+;;; Installation:
+;;
+;;   Drop the `solarized-theme.el` somewhere in your `load-path` and
+;; the two themes in a folder that is on `custom-theme-load-path'
+;; and enjoy!
+;;
+;; Don't forget that the theme requires Emacs 24.
+;;
+;;; Credits
+;;
+;; Ethan Schoonover created the original theme for vim on such this port
+;; is based.
+;;
+;;; Code:
+
 (require 'solarized)
+
 (provide 'solarized-theme)
+;;; solarized-theme.el ends here

--- a/solarized.el
+++ b/solarized.el
@@ -4,10 +4,6 @@
 
 ;; Author: Bozhidar Batsov <bozhidar@batsov.com>
 ;; Author: Thomas Frössman <thomasf@jossystem.se>
-;; URL: http://github.com/bbatsov/solarized-emacs
-;; Version: 1.3.0
-;; Package-Requires: ((emacs "24.1") (dash "2.16"))
-;; Keywords: convenience, themes, solarized
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -23,22 +19,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
-;; A port of Solarized to Emacs.
-;;
-;;; Installation:
-;;
-;;   Drop the `solarized-theme.el` somewhere in your `load-path` and
-;; the two themes in a folder that is on `custom-theme-load-path'
-;; and enjoy!
-;;
-;; Don't forget that the theme requires Emacs 24.
-;;
-;;; Credits
-;;
-;; Ethan Schoonover created the original theme for vim on such this port
-;; is based.
-;;
+
+;; Main solarized file
+
 ;;; Code:
 
 (require 'dash)


### PR DESCRIPTION
Hi!

I found MELPA misunderstood your package information.
But there's no MELPA fail, there're two places to declare package information.

I remove `solarized-theme-pkg.el` and include the information into solarized-theme.el file. Doing so eliminates a place to manage similar information and eliminates the human error of changing only the solarized.el header and forgetting to change the pkg file.

solarized.el declared 'That package depends dash(2.16)' but MELPA recogrize this package 'That package depends dash(2.6)'
![Screenshot_2019-11-06_11-48-57](https://user-images.githubusercontent.com/4703128/68265069-56cf3e80-008e-11ea-9af6-4ee94f05e4a2.png)
