### PR TITLE
Fix file local variables

### DIFF
--- a/solarized-dark-high-contrast-theme.el
+++ b/solarized-dark-high-contrast-theme.el
@@ -35,4 +35,9 @@
 
 
 (provide 'solarized-dark-high-contrast-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-dark-high-contrast-theme.el ends here

--- a/solarized-dark-theme.el
+++ b/solarized-dark-theme.el
@@ -33,4 +33,9 @@
 (provide-theme 'solarized-dark)
 
 (provide 'solarized-dark-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-dark-theme.el ends here

--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1999,4 +1999,9 @@
                                          ,base0 ,violet ,base1 ,base3]))))
 
 (provide 'solarized-faces)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-faces.el ends here

--- a/solarized-gruvbox-dark-theme.el
+++ b/solarized-gruvbox-dark-theme.el
@@ -34,4 +34,9 @@
 (provide-theme 'solarized-gruvbox-dark)
 
 (provide 'solarized-gruvbox-dark-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-gruvbox-dark-theme.el ends here

--- a/solarized-gruvbox-light-theme.el
+++ b/solarized-gruvbox-light-theme.el
@@ -34,4 +34,9 @@
 (provide-theme 'solarized-gruvbox-light)
 
 (provide 'solarized-gruvbox-light-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-gruvbox-light-theme.el ends here

--- a/solarized-light-high-contrast-theme.el
+++ b/solarized-light-high-contrast-theme.el
@@ -34,4 +34,9 @@
 (provide-theme 'solarized-light-high-contrast)
 
 (provide 'solarized-light-high-contrast-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-light-high-contrast-theme.el ends here

--- a/solarized-light-theme.el
+++ b/solarized-light-theme.el
@@ -33,4 +33,9 @@
 (provide-theme 'solarized-light)
 
 (provide 'solarized-light-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-light-theme.el ends here

--- a/solarized-palettes.el
+++ b/solarized-palettes.el
@@ -559,7 +559,11 @@
     ;; palette end
     )
   "The solarized color palette alist.")
+
 (provide 'solarized-palettes)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
 ;; End:
 
 ;;; solarized-palettes.el ends here

--- a/solarized-theme-utils.el
+++ b/solarized-theme-utils.el
@@ -65,9 +65,11 @@ in the format of solarized-theme.el."
                          "")))))
           faces)))
 
+(provide 'solarized-theme-utils)
+
 ;; Local Variables:
 ;; byte-compile-warnings: (not cl-functions)
 ;; indent-tabs-mode: nil
 ;; End:
-(provide 'solarized-theme-utils)
+
 ;;; solarized-theme-utils.el ends here

--- a/solarized-theme.el
+++ b/solarized-theme.el
@@ -44,4 +44,9 @@
 (require 'solarized)
 
 (provide 'solarized-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-theme.el ends here

--- a/solarized-wombat-dark-theme.el
+++ b/solarized-wombat-dark-theme.el
@@ -51,4 +51,9 @@
 (provide-theme 'solarized-wombat-dark)
 
 (provide 'solarized-wombat-dark-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-wombat-dark-theme.el ends here

--- a/solarized-zenburn-theme.el
+++ b/solarized-zenburn-theme.el
@@ -34,4 +34,9 @@
 (provide-theme 'solarized-zenburn)
 
 (provide 'solarized-zenburn-theme)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; solarized-zenburn-theme.el ends here

--- a/solarized.el
+++ b/solarized.el
@@ -444,8 +444,7 @@ If OVERWRITE is non-nil, overwrite theme file if exist."
 (provide 'solarized)
 
 ;; Local Variables:
-;; no-byte-compile: t
 ;; indent-tabs-mode: nil
-;; fill-column: 95
 ;; End:
+
 ;;; solarized.el ends here


### PR DESCRIPTION
Since #353 merged, `solarized.el` could be byte-compile.
I remove the needless `no-byte-compile t` configure and
`indent-tabs-mode nil` in every emacs-lisp files.


----

#