### PR TITLE
Remove dash dependency

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -24,7 +24,6 @@
 
 ;;; Code:
 
-(require 'dash)
 (require 'color)
 (require 'solarized-faces)
 


### PR DESCRIPTION
Hi! I found this package depend dash, but dash function is not used anywhere...?

So I remove dash dependency.  And it is good package no depends such a wrapper library.