### PR TITLE
Rename solarized-faces.el to solarized-definitions.el

### DIFF
--- a/dev-emacs.d/init.el
+++ b/dev-emacs.d/init.el
@@ -127,7 +127,7 @@
   (ignore-errors
     (unload-feature 'solarized t))
   (ignore-errors
-    (unload-feature 'solarized-faces t))
+    (unload-feature 'solarized-definitions t))
   (ignore-errors
     (unload-feature 'solarized-palettes t))
   (dev-set-solarized-settings)

--- a/solarized-definitions.el
+++ b/solarized-definitions.el
@@ -1,4 +1,4 @@
-;;; solarized-faces.el --- the faces definitions for solarized theme  -*- lexical-binding: t -*-
+;;; solarized-definitions.el --- the faces definitions for solarized theme  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 Bozhidar Batsov
 
@@ -2048,10 +2048,10 @@
      `(xterm-color-names-bright [,base03 ,orange ,base01 ,base00
                                          ,base0 ,violet ,base1 ,base3]))))
 
-(provide 'solarized-faces)
+(provide 'solarized-definitions)
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:
 
-;;; solarized-faces.el ends here
+;;; solarized-definitions.el ends here

--- a/solarized.el
+++ b/solarized.el
@@ -25,7 +25,7 @@
 ;;; Code:
 
 (require 'color)
-(require 'solarized-faces)
+(require 'solarized-definitions)
 
 ;;; Options
 


### PR DESCRIPTION
Hi!
I think solarized-faces.el should rename to solarized-definitsions.el

Here is solarized-faces header one-line description.

``` emacs-lisp
the faces definitions for solarized theme
```

And the file define `solarized-definition` variable. So this rename is reasonable for me.