### PR TITLE
Ignore projectile related files in debug emacs.d

### DIFF
--- a/dev-emacs.d/.gitignore
+++ b/dev-emacs.d/.gitignore
@@ -1,3 +1,4 @@
 /elpa/
 /test-repo/
 /transient/
+projectile*


### PR DESCRIPTION
Hi!
I fix `.gitignore` for debug .emacs.d to ensure we committing without unneeded files.