### PR TITLE
Make `org-link` inherit `link-visited`.

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1409,7 +1409,7 @@
                                       :foreground ,red))))
      `(org-level-8 ((,class (:inherit ,s-variable-pitch
                                       :foreground ,blue))))
-     `(org-link ((,class (:foreground ,yellow :underline t))))
+     `(org-link ((,class (:inherit link))))
      `(org-meta-line ((,class (:foreground ,base01 :slant italic))))
      `(org-macro ((,class (:foreground ,s-base1))))
      `(org-sexp-date ((,class (:foreground ,violet))))


### PR DESCRIPTION
It's all in the title, really :) A few other link faces :inherit link already, which has the same definition as `org-link`, so there's probably no reason not to.

Btw, I'm impressed by the customizability of Solarized, thanks a lot for your work on that!   