### PR TITLE
Update built-in completions faces

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -106,7 +106,10 @@
        ((,class (:inherit compilation-error :foreground ,red :weight bold))))
      `(compilation-mode-line-run ((,class (:foreground ,orange :weight bold))))
 ;;;;; completions
-     `(completions-annotations ((t (:foreground ,base01))))
+     ;; like `company-tooltip-annotation'
+     `(completions-annotations ((,class (:foreground ,cyan))))
+     ;; like `company-tooltip-common-selection'
+     `(completions-common-part ((,class (:weight bold))))
 ;;;;; cua
      `(cua-global-mark ((,class (:background ,yellow :foreground ,base03))))
      `(cua-rectangle ((,class (:inherit region


### PR DESCRIPTION
We were not previously customizing `completions-common-part`. Now the
two relevant built-in Completions faces mirror the faces chosen for
Company (as noted).