### PR TITLE
Use s-fringe-bg for unemphasized fringe indicators

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -597,17 +597,17 @@
        ((,class (:foreground ,(if solarized-emphasize-indicators
                                   red-hc red)
                              :background ,(if solarized-emphasize-indicators
-                                              red-lc base03) :weight bold))))
+                                              red-lc s-fringe-bg) :weight bold))))
      `(flycheck-fringe-warning
        ((,class (:foreground ,(if solarized-emphasize-indicators
                                   yellow-hc yellow)
                              :background ,(if solarized-emphasize-indicators
-                                              yellow-lc base03) :weight bold))))
+                                              yellow-lc s-fringe-bg) :weight bold))))
      `(flycheck-fringe-info
        ((,class (:foreground ,(if solarized-emphasize-indicators
                                   blue-hc base01)
                              :background ,(if solarized-emphasize-indicators
-                                              blue-lc base03) :weight bold))))
+                                              blue-lc s-fringe-bg) :weight bold))))
 ;;;;; flymake
      `(flymake-errline
        ((,(append '((supports :underline (:style wave))) class)


### PR DESCRIPTION
Before this commit, when solarized-distinct-fringe-background is t and solarized-emphasize-indicators is nil, the background of flycheck fringe indicators would be the default background not the fringe background. This commit makes the indicators use the distinct fringe background when they are not emphasized.