### PR TITLE
Don't let company-box's scrollbar be invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * window-divider-mode
+* company-box-mode
 
 ### Changes
 

--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -380,6 +380,8 @@
                                                  :inverse-video unspecified))))
 ;;;;; col-highlight
      `(col-highlight ((,class (:background ,base02))))
+;;;;; company-box
+     `(company-box-scrollbar ((,class (:background ,base01))))
 ;;;;; company-mode
      `(company-echo ((,class nil)))
      `(company-echo-common ((,class (:background ,red))))


### PR DESCRIPTION
By default, `company-box-scrollbar` inherits from `company-tooltip-selection`, which by default has a light blue background. Our `company-tooltip-selection` hs no background though, just a bold weight, so it makes the scrollbar invisible. This fixes the problem by theming the scrollbar directly.

Before:
![company-box-scrollbar-before](https://user-images.githubusercontent.com/2374520/99867410-00994480-2b98-11eb-9949-99ce034eae2b.png)

After:
![company-box-scrollbar-after](https://user-images.githubusercontent.com/2374520/99867418-098a1600-2b98-11eb-801e-78a42989df2b.png)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] N/A You've updated the readme (if adding/changing configuration options)
