### PR TITLE
fix selectrum match highlighting

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1557,8 +1557,8 @@
      `(rst-level-6 ((,class (:inherit org-level-6))))
 ;;;;; selectrum-mode
      `(selectrum-current-candidate ((,class (:weight bold :background ,base02 :underline t))))
-     `(selectrum-primary-highlight ((,class (:foreground ,base1))))
-     `(selectrum-secondary-highlight ((,class (:foreground ,yellow))))
+     `(selectrum-primary-highlight ((,class (:foreground ,yellow))))
+     `(selectrum-secondary-highlight ((,class (:foreground ,blue))))
 ;;;;; sh-mode
      `(sh-quoted-exec ((,class (:foreground ,violet :weight bold))))
      `(sh-escaped-newline ((,class (:foreground ,yellow :weight bold))))


### PR DESCRIPTION
fix for selectrum highlights (now consistent with ivy)

before:
<img width="473" alt="old" src="https://user-images.githubusercontent.com/43703153/104057204-a9a00b00-51e9-11eb-973a-e223209a1e54.png">

after:
<img width="473" alt="new" src="https://user-images.githubusercontent.com/43703153/104057226-b15faf80-51e9-11eb-9677-7a98acde52f3.png">


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added a before/after screenshot illustrating visually your changes.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
