### PR TITLE
define-obsolete-function-alias added required 3rd parameter

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -409,7 +409,7 @@ If OVERWRITE is non-nil, overwrite theme file if exist."
   (let ((color-palette (solarized-create-color-palette core-palette)))
     (apply #'solarized-create-theme-file (list variant theme-name color-palette childtheme-sexp overwrite))))
 
-(define-obsolete-function-alias 'create-solarized-theme-file 'solarized-create-theme-file)
+(define-obsolete-function-alias 'create-solarized-theme-file 'solarized-create-theme-file "1.3.0")
 
 ;;; Footer
 


### PR DESCRIPTION
The function `define-obsolete-function-alias` changed its optional third parameter into a required parameter, which is a string indicating when or at which version the old function became obsolete.  This change simply adds the required third parameter using "26".  Without this change, `solarized.el` creates an error which prevents the theme from being loaded, but also prevents any other theme from being loaded via the `customize-themes' function.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)

Thanks!
