### PR TITLE
add support for orderless

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1366,7 +1366,11 @@
      `(notmuch-tree-match-date-face ((,class (:foreground ,yellow))))
      `(notmuch-tree-match-tag-face ((,class (:foreground ,cyan))))
      `(notmuch-tree-no-match-face ((,class (:inherit font-lock-comment-face))))
-
+;;;;; orderless
+     `(orderless-match-face-0 ((,class (:foreground ,yellow))))
+     `(orderless-match-face-1 ((,class (:foreground ,blue))))
+     `(orderless-match-face-2 ((,class (:foreground ,green))))
+     `(orderless-match-face-3 ((,class (:foreground ,magenta))))
 ;;;;; org-mode
      `(org-agenda-structure
        ((,class (:foreground ,base1 :background ,base02


### PR DESCRIPTION
This adds support for the [orderless](https://github.com/oantolin/orderless) completion style.

current
<img width="574" alt="1" src="https://user-images.githubusercontent.com/43703153/105756535-ab393500-5f44-11eb-9532-4d9855a3c2b3.png">

new
<img width="574" alt="2" src="https://user-images.githubusercontent.com/43703153/105756581-b3917000-5f44-11eb-8118-5b21cbf6f022.png">

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.

Thanks!
