### PR TITLE
switch orderless colors

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1367,10 +1367,10 @@
      `(notmuch-tree-match-tag-face ((,class (:foreground ,cyan))))
      `(notmuch-tree-no-match-face ((,class (:inherit font-lock-comment-face))))
 ;;;;; orderless
-     `(orderless-match-face-0 ((,class (:foreground ,yellow))))
-     `(orderless-match-face-1 ((,class (:foreground ,blue))))
-     `(orderless-match-face-2 ((,class (:foreground ,green))))
-     `(orderless-match-face-3 ((,class (:foreground ,magenta))))
+     `(orderless-match-face-0 ((,class (:foreground ,blue))))
+     `(orderless-match-face-1 ((,class (:foreground ,magenta))))
+     `(orderless-match-face-2 ((,class (:foreground ,yellow))))
+     `(orderless-match-face-3 ((,class (:foreground ,green))))
 ;;;;; org-mode
      `(org-agenda-structure
        ((,class (:foreground ,base1 :background ,base02


### PR DESCRIPTION
As discussed [here](https://github.com/bbatsov/solarized-emacs/pull/413#issuecomment-767486956), now with different colour ordering. Now it goes blue -> magenta -> yellow -> green. I find it pleasant to start with blue and actually it works quite nicely that magenta which comes next is then a bit more "powerful" than blue; yellow also has quite good contrast compared to the others and these will probably the ones are seen most frequently by the majority of users.

Hope that is fine!

PS: thanks for maintaining this fantastic theme!

<img width="574" alt="light" src="https://user-images.githubusercontent.com/43703153/105892755-329cac00-600a-11eb-88ea-a143fbd19062.png">
<img width="574" alt="dark" src="https://user-images.githubusercontent.com/43703153/105892763-34666f80-600a-11eb-9b62-c72eac82e1e8.png">

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] You've added a before/after screenshot illustrating visually your changes.

Thanks!
