### PR TITLE
Add help-key-binding face

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -54,6 +54,7 @@
      `(link-visited ((,class (:foreground ,yellow :underline t :weight normal))))
      `(match ((,class (:background ,base02 :foreground ,base1 :weight bold))))
      `(menu ((,class (:foreground ,base0 :background ,base03))))
+     `(help-key-binding ((,class (:box (:line-width (1 . -1) :color ,s-line :style nil) :background ,base02))))
      `(minibuffer-prompt ((,class (:foreground ,base0))))
      `(mode-line
        ((,class (:inverse-video unspecified


### PR DESCRIPTION
In emacs 28.1 there's a new face `help-key-binding` to decorate key bindings

* Before:
![before](https://user-images.githubusercontent.com/1837971/118632527-ccae7d00-b7d0-11eb-9d05-63c30a555999.png)

* After:
![after](https://user-images.githubusercontent.com/1837971/118633363-b0f7a680-b7d1-11eb-9622-b7b936b12dcd.png)
