### PR TITLE
Improve handling of auto-highlight-symbol after upstream changes

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -325,10 +325,14 @@
 ;;;;; auto-highlight-symbol
      `(ahs-definition-face ((,class (:foreground ,magenta :background unspecified
                                                  :slant normal))))
+     `(ahs-definition-face-unfocused ((,class (:foreground ,magenta :background unspecified
+                                                           :slant normal))))
      `(ahs-edit-mode-face ((,class (:foreground ,base03 :background ,magenta))))
      `(ahs-face ((,class (:foreground ,magenta :background unspecified))))
+     `(ahs-face-unfocused ((,class (:foreground ,magenta :background unspecified))))
      `(ahs-plugin-bod-face ((,class (:foreground ,magenta :background unspecified ))))
-     `(ahs-plugin-defalt-face ((,class (:foreground ,magenta :background unspecified))))
+     `(ahs-plugin-default-face ((,class (:foreground ,magenta :background unspecified))))
+     `(ahs-plugin-default-face-unfocused ((,class (:foreground ,magenta :background unspecified))))
      `(ahs-plugin-whole-buffer-face ((,class (:foreground ,magenta  :background unspecified))))
      `(ahs-warning-face ((,class (:foreground ,red :weight bold))))
 ;;;;; avy-mode


### PR DESCRIPTION
This commit accommodates to the following upstream changes:
* `ahs-plugin-defalt-face` was renamed to `ahs-plugin-default-face`
* Several new *-unfocused faces were introduced (e.g. `ahs-face-unfocsed`).

All the mentioned faces are themed exactly the same way the `ahs-face` is.

Please note that the upstream changes to `auto-highlight-symbol` affect Spacemacs (see  syl20bnr/spacemacs#14880) users who happen to use solarized theme. Thus please consider merging this at your earliest opportunity.

Before:
![solarized-theme-before](https://user-images.githubusercontent.com/2280844/124607114-0f014b80-de5d-11eb-8216-55a0e2c6e2c5.png)

After:
![solarized-theme-after](https://user-images.githubusercontent.com/2280844/124607156-1aed0d80-de5d-11eb-848e-a238de387ddf.png)
