### PR TITLE
Add option to scale markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ elisp code:
 ;; Don't change size of org-mode headlines (but keep other size-changes)
 (setq solarized-scale-org-headlines nil)
 
+;; Change the size of markdown-mode headlines (off by default)
+(setq solarized-scale-markdown-headlines t)
+
 ;; Avoid all font-size changes
 (setq solarized-height-minus-1 1.0)
 (setq solarized-height-plus-1 1.0)

--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1180,10 +1180,18 @@
      `(markdown-footnote-face ((,class (:inherit default))))
      `(markdown-header-delimiter-face ((,class (:foreground ,base01))))
      `(markdown-header-face ((,class (:foreground ,blue))))
-     `(markdown-header-face-1 ((,class (:inherit markdown-header-face))))
-     `(markdown-header-face-2 ((,class (:inherit markdown-header-face))))
-     `(markdown-header-face-3 ((,class (:inherit markdown-header-face))))
-     `(markdown-header-face-4 ((,class (:inherit markdown-header-face))))
+     `(markdown-header-face-1 ((,class (:inherit markdown-header-face
+                                                 ,@(when solarized-scale-markdown-headlines
+                                                     (list :height solarized-height-plus-4))))))
+     `(markdown-header-face-2 ((,class (:inherit markdown-header-face
+                                                 ,@(when solarized-scale-markdown-headlines
+                                                     (list :height solarized-height-plus-3))))))
+     `(markdown-header-face-3 ((,class (:inherit markdown-header-face
+                                                 ,@(when solarized-scale-markdown-headlines
+                                                     (list :height solarized-height-plus-2))))))
+     `(markdown-header-face-4 ((,class (:inherit markdown-header-face
+                                                 ,@(when solarized-scale-markdown-headlines
+                                                     (list :height solarized-height-plus-1))))))
      `(markdown-header-face-5 ((,class (:inherit markdown-header-face))))
      `(markdown-header-face-6 ((,class (:inherit markdown-header-face))))
      `(markdown-header-rule-face ((,class (:foreground ,base01))))

--- a/solarized.el
+++ b/solarized.el
@@ -107,6 +107,11 @@ Related discussion: https://github.com/bbatsov/solarized-emacs/issues/158"
   :type 'boolean
   :group 'solarized)
 
+(defcustom solarized-scale-markdown-headlines nil
+  "Whether `markdown-mode' headlines should be scaled."
+  :type 'boolean
+  :group 'solarized)
+
 (defcustom solarized-scale-outline-headlines t
   "Whether `outline-mode' headlines should be scaled."
   :type 'boolean


### PR DESCRIPTION
It bothered me that solarized was getting in the way of `markdown-mode`'s built in ability to scale headers, so I tweaked `solarized-faces.el` to copy the behavior from the scaling of `org-mode` headers, but left it off by default.

Before: 
![Before](https://user-images.githubusercontent.com/8325047/125552263-56de77aa-ad64-4d32-80e2-ceee0c535ace.png)

After:
![After](https://user-images.githubusercontent.com/8325047/125552278-a5985222-8bfb-4403-832f-ba41551ef8d9.png)
