### PR TITLE
Don't theme magit-branch-current explicitly

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1151,7 +1151,6 @@
      `(magit-tag            ((t (:foreground ,cyan   :weight bold))))
      `(magit-branch-remote  ((t (:foreground ,green  :weight bold))))
      `(magit-branch-local   ((t (:foreground ,blue   :weight bold))))
-     `(magit-branch-current ((t (:foreground ,blue   :weight bold :box t))))
      `(magit-head           ((t (:foreground ,blue   :weight bold))))
      `(magit-refname        ((t (:background ,base02 :foreground ,base01 :weight bold))))
      `(magit-refname-stash  ((t (:background ,base02 :foreground ,base01 :weight bold))))


### PR DESCRIPTION
Due to the upstream definition inheriting from `magit-branch-local`
it is unnecessary to redefine this face when the `:box` attribute
is supported.  And when that is not supported (on a terminal), then
not overriding the definition means that the upstream fallback for
this situation is automatically used.
