### PR TITLE
Add consult support

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -417,7 +417,9 @@
      `(company-tooltip-search ((,class (:foreground ,magenta))))
      `(company-tooltip-search-selection ((,class (:foreground ,magenta :weight bold))))
      `(company-tooltip-selection ((,class (:weight bold))))
-
+;;;;; consult
+     `(consult-preview-insertion ((,class (:background ,base02))))
+     `(consult-preview-line ((,class (:background ,base02))))
 ;;;;; cperl-mode
      `(cperl-array-face ((,class (:background unspecified :foreground ,blue))))
      `(cperl-hash-face ((,class (:background unspecified :foreground ,blue))))


### PR DESCRIPTION
By default, these faces inherit from `region`, which is not very pleasant to look at. This PR changes them so they only highlight the lines' background.

`consult-preview-line` highlights lines you are searching for, on commands such as `consult-line` or `consult-grep`, and `consult-preview-insertion` highlights a preview of a yank when calling `consult-yank-pop`.

consult-preview-line before/after:
![consult-preview-line before](https://user-images.githubusercontent.com/2374520/129845955-b2999d25-7b83-4bfa-a03f-87c31337cc2f.png)
![consult-preview-line after](https://user-images.githubusercontent.com/2374520/129845994-067c45ec-99f1-41be-a31e-ee1520c7302f.png)

consult-preview-insertion before/after:
![consult-preview-insertion before](https://user-images.githubusercontent.com/2374520/129846089-d8c9632c-6b8f-4811-9625-2c7032128cc0.png)
![consult-preview-insertion after](https://user-images.githubusercontent.com/2374520/129846102-3419a17a-806e-4a83-ab74-b97321910acd.png)



-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.
- [N/A] You've updated the readme (if adding/changing configuration options)

Thanks!
