### PR TITLE
Remove underline in the doom modeline mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ manner as the vertical border.
 (setq x-underline-at-descent-line t)
 ```
 
+### Underline setting for doom-modeline-mode
+
+For users who want to fix the ugly doom-modeline-mode underline the setting
+`solarized-doom-mode-line-underline` which will remove the underline completely.
+
+```el
+(setq solarized-doom-mode-line-underline nil)
+```
+
 ## Create theme using color palette
 
 The Solarized Face settings consist of a palette of colors with eight

--- a/dev-emacs.d/lisp/solarized-dev.el
+++ b/dev-emacs.d/lisp/solarized-dev.el
@@ -20,6 +20,7 @@
    solarized-height-plus-4 1.3
    solarized-scale-org-headlines t
    solarized-scale-outline-headlines t
+   solarized-doom-mode-line-underline nil
    ;; end
    ))
 

--- a/solarized.el
+++ b/solarized.el
@@ -292,6 +292,7 @@ customize the resulting theme."
             ;; NOTE only use this for very thin lines that are hard to see using base02, in low
             ;; color displayes base02 might be used instead
             (s-line (if (eq variant 'light) "#cccec4" "#284b54"))
+            (no-line (if (eq variant 'light) nil nil))
 
             ;; Light/Dark adaptive higher/lower contrast accented colors
             ;;
@@ -337,6 +338,8 @@ customize the resulting theme."
                                 base0 base02))
             (s-mode-line-underline (if solarized-high-contrast-mode-line
                                        nil s-line))
+            (s-mode-line-underline (if solarized-doom-mode-line-underline
+                                       nil no-line))
 
             (s-mode-line-buffer-id-fg (if solarized-high-contrast-mode-line
                                           'unspecified base1))

--- a/solarized.el
+++ b/solarized.el
@@ -77,6 +77,11 @@ Related discussion: https://github.com/bbatsov/solarized-emacs/issues/158"
   :type 'boolean
   :group 'solarized)
 
+(defcustom solarized-doom-mode-line-underline nil
+  "Remove the underline in the doom modeline."
+  :type 'boolean
+  :group 'solarized)
+
 (defcustom solarized-height-minus-1 0.8
   "Font size -1."
   :type 'number


### PR DESCRIPTION
**Dear Bug, 
I added a simple boolean that sets the underline from the mode-line to nil when
using doom-modeline-mode. It was quite ugly with it, check the "Before" screenshot,
so I decided to get rid of it.**

-----------------

- [ x ] I've added a before/after screenshot illustrating visually my changes.

1. Before
![Screenshot_Before](https://user-images.githubusercontent.com/42769725/142736193-7de74303-c1b3-49cd-a9a7-2b3612b41db9.png)

2. After
![Screenshot_After](https://user-images.githubusercontent.com/42769725/142736199-c3275867-cc1d-45ed-a847-09761d3379d8.png)

- [ x ] I've updated the readme with the following section.

> ### Underline setting for doom-modeline-mode
> 
> For users who want to fix the ugly doom-modeline-mode underline the setting
> `solarized-doom-mode-line-underline` which will remove the underline completely.
> 
> ```el
> (setq solarized-doom-mode-line-underline nil)
> ```

Thank you!
