### PR TITLE
Add missing faces for tab-bar mode

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1767,6 +1767,10 @@
 ;;;;;; misc
      `(sr-clex-hotchar-face ((,class (:background ,red  :foreground ,base03
                                                   :weight bold))))
+;;;;; tab-bar
+     `(tab-bar ((t (:background ,base03 :foreground ,base0))))
+     `(tab-bar-tab ((t (:background ,base03 :foreground ,base1))))
+     `(tab-bar-tab-inactive ((t (:background ,base02 :foreground ,base01))))
 ;;;;; tabbar
      `(tabbar-default ((,class (:foreground ,base03 :background ,base03))))
      `(tabbar-highlight ((,class (:underline t))))


### PR DESCRIPTION
# Purpose
This is meant to address issue #427. The user @exot came up with a sample custom theme for tab-bar but never initiated a pull request.

I came up with a much less sophisticated tab-bar face based off of the [tab-bar face of a gruvbox theme](https://github.com/greduan/emacs-theme-gruvbox/blob/921bfd7a2f5174b68682b04e6010b156bbfe6c70/gruvbox.el#L746-L749) and the coloring used in the [centaur-tabs face of this solarized theme](https://github.com/bbatsov/solarized-emacs/blob/f34a171ff0e39549972edf533120f0b556f0b5ad/solarized-faces.el#L1780-L1783).

# Examples (Before and After)
Attached are some examples of what the tab-bar looks like before and after these changes. The examples show `solarized-light` and `solarized-dark` with tab-bar buttons enabled (default) and disabled (my preference).

## solarized-light with tab-bar buttons enabled
<img width="715" alt="before light with buttons" src="https://user-images.githubusercontent.com/12476831/159190985-5d35c570-98f9-45cd-85e0-e662a7f1b8f4.png">
<img width="724" alt="after light with buttons" src="https://user-images.githubusercontent.com/12476831/159190992-1316eeae-fecf-47f0-b695-df8ed895a48d.png">

## solarized-dark with tab-bar buttons enabled
<img width="713" alt="before dark with buttons" src="https://user-images.githubusercontent.com/12476831/159190988-99259f72-d8ba-4efe-a5ae-7124feed3c3b.png">
<img width="722" alt="after dark with buttons" src="https://user-images.githubusercontent.com/12476831/159190994-491a6948-464e-47bf-b313-4c7203fba71b.png">

## solarized-light with tab-bar buttons disabled
<img width="714" alt="before light no buttons" src="https://user-images.githubusercontent.com/12476831/159190991-c501c02d-94d2-40af-b1e7-1c91de2c3391.png">
<img width="725" alt="after light no buttons" src="https://user-images.githubusercontent.com/12476831/159190997-0406f07c-462c-4feb-91ad-e93cf9ce82b7.png">

## solarized-dark with tab-bar buttons disabled
<img width="715" alt="before dark no buttons" src="https://user-images.githubusercontent.com/12476831/159190989-25e9b24a-d67e-439f-b5a1-670fdc674f34.png">
<img width="722" alt="after dark no buttons" src="https://user-images.githubusercontent.com/12476831/159190996-b9d46dca-4605-4512-b462-9d1a243f4301.png">

# No updates to readme
I didn't make any updates to the readme and don't believe I have to.

-----------------

- [X] I've added a before/after screenshot illustrating visually your changes.
- [x] I've updated the readme (if adding/changing configuration options)
