### PR TITLE
Add more helm-find-files faces

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -808,9 +808,14 @@
      `(helm-buffer-size ((,class (:foreground ,base01))))
      `(helm-candidate-number ((,class (:background ,base02 :foreground ,base1
                                                    :bold t))))
+     `(helm-ff-dotted-directory ((,class (:foreground ,base03 :background ,base01))))
      `(helm-ff-directory ((,class (:background ,base03  :foreground ,blue))))
      `(helm-ff-executable ((,class (:foreground ,green))))
+     `(helm-ff-socket ((,class (:foreground ,magenta))))
+     `(helm-ff-pipe ((,class (:foreground ,yellow))))
+     `(helm-ff-suid ((,class (:foreground ,base03 :background ,red))))
      `(helm-ff-file ((,class (:background ,base03 :foreground ,base0))))
+     `(helm-ff-backup-file ((,class (:foreground ,base01))))
      `(helm-ff-invalid-symlink ((,class (:background ,base03 :foreground ,orange
                                                      :slant italic))))
      `(helm-ff-prefix ((,class (:background ,yellow :foreground ,base03))))


### PR DESCRIPTION
dotted directory, socket, pipe, suid, backup-file
Colors taken from the default `ls --color` output.

![Before](https://user-images.githubusercontent.com/75352049/159819718-3b6b788a-cc2e-48b7-b740-faf68863071c.png)
![After](https://user-images.githubusercontent.com/75352049/159819788-e34981c6-4f5d-423f-a9fa-9c7f23d31dad.png) 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] You've added a before/after screenshot illustrating visually your changes.
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
