### PR TITLE
Add 'ansi-color-*' faces for Emacs 28.1

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -87,6 +87,21 @@
      `(warning ((,class (:foreground ,yellow ))))
      `(next-error ((,class (:foreground ,magenta-2fg :background ,magenta-2bg :weight normal))))
 
+;;;;; ansi-color
+     `(ansi-color-black ((,class (:foreground ,base1 :background ,base1))))
+     `(ansi-color-red ((,class (:foreground ,red :background ,red))))
+     `(ansi-color-green ((,class (:foreground ,green :background ,green))))
+     `(ansi-color-yellow ((,class (:foreground ,yellow :background ,yellow))))
+     `(ansi-color-blue ((,class (:foreground ,blue :background ,blue))))
+     `(ansi-color-magenta ((,class (:foreground ,magenta :background ,magenta))))
+     `(ansi-color-cyan ((,class (:foreground ,cyan :background ,cyan))))
+     `(ansi-color-bright-black ((,class (:foreground ,base0 :background ,base0))))
+     `(ansi-color-bright-red ((,class (:foreground ,red-l :background ,red-l))))
+     `(ansi-color-bright-green ((,class (:foreground ,green-l :background ,green-l))))
+     `(ansi-color-bright-yellow ((,class (:foreground ,yellow-l :background ,yellow-l))))
+     `(ansi-color-bright-blue ((,class (:foreground ,blue-l :background ,blue-l))))
+     `(ansi-color-bright-magenta ((,class (:foreground ,magenta-l :background ,magenta-l))))
+     `(ansi-color-bright-cyan ((,class (:foreground ,cyan-l :background ,cyan-l))))
 ;;;;; compilation
      `(compilation-column-face ((,class (:foreground ,cyan :underline nil))))
      `(compilation-column-number ((,class (:inherit font-lock-doc-face :foreground ,cyan


### PR DESCRIPTION
Emacs 28 [introduced new faces for ANSI color codes](https://github.com/emacs-mirror/emacs/blob/emacs-28/lisp/ansi-color.el#L93-L228), that are applied by the `ansi-color-compilation-filter` function. This adds Solarized color mappings for those faces.

I don't know whether there are great options for the 'black' and 'white' faces (and their 'bright' variants). I left 'white' at its default, and made the best choice I could for 'black', that hopefully makes sense for both dark and light palettes. I'm very open to alternate suggestions for those.

Default colors:

<img width="1052" alt="Screen Shot 2022-04-30 at 10 41 11 AM" src="https://user-images.githubusercontent.com/761245/166116983-88b5a4c6-7503-4450-9cf7-6b671b21b23a.png">

With this patch:

<img width="1052" alt="Screen Shot 2022-04-30 at 10 53 43 AM" src="https://user-images.githubusercontent.com/761245/166116986-00759513-2042-424a-8447-094625a1f558.png">

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the readme (if adding/changing configuration options) **N/A**

Thanks!
