### PR TITLE
Use extra-light instead of thin for line numbers

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1051,10 +1051,10 @@
      `(ledger-font-reconciler-pending-face ((t (:foreground ,yellow :weight normal))))
      `(ledger-font-report-clickable-face ((t (:foreground ,yellow :weight normal))))
 ;;;;; linum-mode
-     `(linum ((,class (:weight thin :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
+     `(linum ((,class (:weight extra-light :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
      `(linum-relative-current-face ((,class (:inherit linum))))
 ;;;;; display-line-number-mode
-     `(line-number ((,class (:weight thin :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
+     `(line-number ((,class (:weight extra-light :underline nil :foreground ,s-fringe-fg :background ,s-fringe-bg))))
      `(line-number-minor-tick ((,class (:inherit line-number :weight normal))))
      `(line-number-major-tick ((,class (:inherit line-number-minor-tick :weight bold))))
      `(line-number-current-line ((,class (:inherit line-number :background ,base03 :foreground ,base0))))


### PR DESCRIPTION
#305 was a great but thin is *too* thin for fonts which support many
weights. This replaces thin by extra-light, which is still visibly
different from the normal weight but also still legible.

In fact, it's so thin, it's not even documented, see
https://github.com/emacs-mirror/emacs/blob/master/src/font.c#L71
https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html

Screenshots (with Iosevka):
![Screenshot from 2022-08-19 14-12-59](https://user-images.githubusercontent.com/1071625/185620524-c54884ce-7059-4220-80b9-99468f88bf26.png)
![image](https://user-images.githubusercontent.com/1071625/185620499-d94c3698-0472-4dc6-ae09-e25a4ae0c4a5.png)

Note that these screenshots are upscaled 200% from hidpi screen, so legibility of thin was even worse in practice.
