### PR TITLE
fix compiler error

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -251,8 +251,8 @@ The Returned color-palette has the same format as `solarized-color-palette'"
 ;;; Setup Start
 (defmacro solarized-with-color-variables (variant theme-name color-palette &optional childtheme-sexp)
   "Eval `solarized-definition' in solarized COLOR-PALETTE for THEME-NAME.
-VARIANT is 'dark or 'light.
-When optional argument CHILDTHEME-SEXP sexp is supplied it's invoked to further
+VARIANT is \\='dark or \\='light.
+When optional argument CHILDTHEME-SEXP sexp is supplied it\\='s invoked to further
 customize the resulting theme."
   (declare (indent defun))
   (let ((color-palette* (eval color-palette)))


### PR DESCRIPTION
Made changes to remove compiler error:

```
⛔ Warning (comp): solarized.el:252:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)
```

More information here:

https://emacs.stackexchange.com/questions/73047/emacs-29-docstring-single-quote-escaping-rules-compiler-level-event
https://www.gnu.org/software/emacs/manual/html_node/elisp/Keys-in-Documentation

I am not sure of the necessity in the case of the KEYSEQ.
