### PR TITLE
Remove all-the-icons-dired-dir-face

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -260,7 +260,6 @@
      `(spaceline-all-the-icons-info-face ((,class (:foreground ,blue))))
      `(spaceline-all-the-icons-sunrise-face ((,class (:foreground ,yellow))))
      `(spaceline-all-the-icons-sunrise-face ((,class (:foreground ,orange))))
-     `(all-the-icons-dired-dir-face ((,class (:foreground ,base0))))
      `(all-the-icons-red ((,class (:foreground ,red))))
      `(all-the-icons-lred ((,class (:foreground ,red-lc))))
      `(all-the-icons-dred ((,class (:foreground ,red-hc))))


### PR DESCRIPTION
This is no longer needed as `all-the-icons-dired` now has this face [inherits from dired-directory](https://github.com/wyuenho/all-the-icons-dired/commit/b3dd838e93325145bb55cec69d8b0a2b6f1bc348)