### PR TITLE
Fix invalid `:style unspecified` box properties

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -46,7 +46,7 @@
                                 :foreground ,s-header-line-fg
                                 :background ,s-header-line-bg
                                 :box (:line-width 2 :color ,s-header-line-bg
-                                                  :style unspecified)))))
+                                                  :style nil)))))
      `(highlight ((,class (:background ,base02))))
      `(lazy-highlight ((,class (:foreground ,base03 :background ,yellow
                                             :weight normal))))
@@ -63,7 +63,7 @@
                                 :foreground ,s-mode-line-fg
                                 :background ,s-mode-line-bg
                                 :box (:line-width 1 :color ,s-mode-line-bg
-                                                  :style unspecified)))))
+                                                  :style nil)))))
      `(mode-line-buffer-id ((,class (:foreground ,s-mode-line-buffer-id-fg :weight bold))))
      `(mode-line-inactive
        ((,class (:inverse-video unspecified
@@ -72,7 +72,7 @@
                                 :foreground ,s-mode-line-inactive-fg
                                 :background ,s-mode-line-inactive-bg
                                 :box (:line-width 1 :color ,s-mode-line-inactive-bg
-                                                  :style unspecified)))))
+                                                  :style nil)))))
      `(region
        ((,class (,@(and (>= emacs-major-version 27) '(:extend t))
                  :foreground ,base03


### PR DESCRIPTION
Fixes #447 

`unspecified` is not a valid `style` for `:box` properties, but it wasn't rejected because of a bug in Emacs that would allow invalid attributes of `:box` so long as it was the last one in the list. This has been recently fixed in Emacs' master branch (see [this](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=dcd755dabcf9ef95d6d0534c11c668f44c6f89c2) commit).