### PR TITLE
Highlight font-lock-number-face as highlight-numbers-number

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ elisp code:
 (setq solarized-height-plus-3 1.0)
 (setq solarized-height-plus-4 1.0)
 
+;; Highlight all numbers
+(setq solarized-highlight-numbers t)
+
 ```
 
 Note that these need to be set **before** `load-theme` is invoked for Solarized.

--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -236,6 +236,7 @@
        ((,class (:foreground ,base01 :slant ,s-maybe-italic))))
      `(font-lock-comment-face ((,class (:foreground ,base01))))
      `(font-lock-constant-face ((,class (:foreground ,blue :weight bold))))
+     `(font-lock-number-face ((,class (:foreground ,(if solarized-highlight-numbers violet 'unspecified)))))
      `(font-lock-doc-face ((,class (:foreground ,(if solarized-distinct-doc-face violet cyan)
                                                 :slant ,s-maybe-italic))))
      `(font-lock-function-name-face ((,class (:foreground ,blue))))
@@ -919,7 +920,7 @@
      `(highlight-indentation-face ((,class (:background ,base02))))
      `(highlight-indentation-current-column-face((,class (:background ,base02))))
 ;;;;; highlight-numbers
-     `(highlight-numbers-number ((,class (:foreground ,violet :bold nil))))
+     `(highlight-numbers-number ((,class (:inherit font-lock-number-face))))
 ;;;;; highlight-symbol
      `(highlight-symbol-face ((,class (:foreground ,magenta))))
 ;;;;; hl-line-mode

--- a/solarized.el
+++ b/solarized.el
@@ -52,6 +52,13 @@ Related discussion: https://github.com/bbatsov/solarized-emacs/issues/158"
   :type 'boolean
   :group 'solarized)
 
+(defcustom solarized-highlight-numbers nil
+  "Highlight all numbers.
+Applies color to `font-lock-number-face' and `highlight-numbers' mode.
+Many tree-sitter based modes use `font-lock-number-face'."
+  :type 'boolean
+  :group 'solarized)
+
 (defcustom solarized-use-variable-pitch t
   "Use variable pitch face for some headings and titles."
   :type 'boolean


### PR DESCRIPTION
We already support `highlight-numbers` (by highlighting `highlight-numbers-number`). This PR uses the same font for `font-lock` (highlighting `font-lock-number-face`).

This fixes the inconsistency if you use both `highlight-numbers` and something which uses `font-lock`. For example, `ruby-mode` and `ruby-ts-mode`. For example, notice how the numbers are not highlighted only in the top-left cell in the following table:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![image](https://github.com/bbatsov/solarized-emacs/assets/10100907/f708edf9-4936-4bb8-935a-b33495bb33e6)
</td>
<td>

![image](https://github.com/bbatsov/solarized-emacs/assets/10100907/9e3574d6-f358-43d8-a7db-8139294f508c)
</td>
</tr>
<tr>
<td>

![image](https://github.com/bbatsov/solarized-emacs/assets/10100907/b3fc5612-a59b-47fa-b44d-4a68e4d7b9b4)
</td>
<td>

![image](https://github.com/bbatsov/solarized-emacs/assets/10100907/2adc4b70-8b92-4026-b484-9ab910582732)
</td>
</tr>
</table>
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the readme (if adding/changing configuration options)

Thanks!
