### PR TITLE
Add support for built in Emacs packages: tab-line and window-tool-bar

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -1805,6 +1805,14 @@
      `(tabbar-unselected-modified ((,class (:inherit tabbar-modified :background ,base02 :underline nil :box (:line-width 1 :color ,base03)))))
      `(tabbar-selected ((,class (:inherit tabbar-default :foreground ,base3 :background ,base03 :weight bold :underline nil :box (:line-width 1 :color ,base03)))))
      `(tabbar-selected-modified ((,class (:inherit tabbar-selected :foreground ,blue :underline nil :box (:line-width 1 :color ,base03)))))
+;;;;; tab-line
+     `(tab-line ((t (:background ,base03 :foreground ,base0))))
+     `(tab-line-highlight ((,class (:underline t))))
+     `(tab-line-tab ((t (:background ,base03 :foreground ,base1))))
+     `(tab-line-tab-current ((,class (:inherit tab-line-tab :underline nil))))
+     `(tab-line-tab-inactive ((,class (:inherit tab-line-tab :background ,base02 :foreground ,base01))))
+     `(tab-line-tab-inactive-alternate ((,class (:inherit tab-line-tab-inactive))))
+     `(tab-line-tab-modified ((,class (:inherit tab-line-tab :foreground ,blue))))
 ;;;;; centaur-tabs
    `(centaur-tabs-default ((t (:background ,base03 :foreground ,base0 :box nil))))
    `(centaur-tabs-selected ((t (:background ,base03 :foreground ,base1 :box nil))))

--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -2049,6 +2049,10 @@
      `(window-divider-last-pixel ((,class (:foreground ,s-mode-line-bg))))
 ;;;;; window-number-mode
      `(window-number-face ((,class (:foreground ,green))))
+;;;;; window-tool-bar-mode
+     `(window-tool-bar-button ((,class (:inherit tab-line))) )
+     `(window-tool-bar-button-hover ((,class (:background ,base02 :foreground ,base1))))
+     `(window-tool-bar-button-disabled ((,class (:background ,red-1bg :foreground ,base0))))
 ;;;;; woman
      `(woman-bold ((,class (:inherit Man-overstrike))))
      `(woman-italic ((,class (:inherit Man-underline))))


### PR DESCRIPTION
This adds theme support for tab-line (added in Emacs 27) and window-tool-bar (added in Emacs 30). I am the author of window-tool-bar.el and am going through top themes making sure they all have support.

Note that the after screenshot doesn't show the "disabled" state, which I did with a the red-1bg background. Ideally this would be a desaturated color to indicate "disabled", but I couldn't find such an option.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.
    -   Before  
        ![before](https://github.com/bbatsov/solarized-emacs/assets/9546385/98712fc0-3ce6-44d3-bbeb-f3e691968b2b)
    -   After  
        ![after](https://github.com/bbatsov/solarized-emacs/assets/9546385/4e0c5947-c1e2-4cec-b1f7-8999ab831476)
- [x] You've updated the readme (if adding/changing configuration options)
    - Not applicable