### PR TITLE
Update flymake -error, -warning, and -note to match flycheck

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -650,6 +650,19 @@
                              :background ,(if solarized-emphasize-indicators
                                               blue-lc s-fringe-bg) :weight bold))))
 ;;;;; flymake
+     `(flymake-error
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,red) :inherit unspecified))
+        (,class (:foreground ,red-hc :background ,red-lc :weight bold :underline t))))
+     `(flymake-warning
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,yellow) :inherit unspecified))
+        (,class (:foreground ,yellow-hc :background ,yellow-lc :weight bold :underline t))))
+     `(flymake-note
+       ((,(append '((supports :underline (:style wave))) class)
+         (:underline (:style wave :color ,(if solarized-emphasize-indicators
+                                              blue base03)) :inherit unspecified))
+        (,class (:foreground ,blue-hc :background ,blue-lc :weight bold :underline t))))
      `(flymake-errline
        ((,(append '((supports :underline (:style wave))) class)
          (:underline (:style wave :color ,red) :inherit unspecified


### PR DESCRIPTION
This commit updates the faces for Flymake's reported errors, warnings, and notes to make them more visible in non-GUI environments.

The faces were copied from their `flycheck` counterparts for consistency.

Before 
![flymake-error-warning-before](https://github.com/user-attachments/assets/cf238b99-bfeb-4d2d-ac1e-94a69c437b32)

After
![flymake-error-warning-after](https://github.com/user-attachments/assets/a937f2bd-4fea-40a1-b85e-1e5c586c99ec)

Screenshots from a 24-bit true-color terminal

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the readme (if adding/changing configuration options) (N/A)

Thanks!
