### PR TITLE
Honor load-theme's NO-ENABLE instead of forcing faces on load

### DIFF
--- a/solarized.el
+++ b/solarized.el
@@ -397,11 +397,15 @@ customize the resulting theme."
                s-diff-fine-C-bg s-diff-fine-C-fg s-diff-context-fg
                s-diff-heading-bg s-diffstat-added-fg
                s-diffstat-changed-fg s-diffstat-removed-fg)
-       ;; NOTE: `custom--inhibit-theme-enable' turn-off needed
-       ;;       childtheme works well discussed in #352
-       (let ((custom--inhibit-theme-enable nil))
-         ,@solarized-definition
-         ,@(eval childtheme-sexp)))))
+       ;; Emit the child theme's faces *before* the base definition.
+       ;; `custom-theme-set-faces' keeps the first spec it sees for a
+       ;; given face, so this is what lets a child theme override the
+       ;; base faces (#352).  Doing it through ordering, rather than by
+       ;; binding `custom--inhibit-theme-enable' to nil, means we no
+       ;; longer force the faces to apply during loading and thus honor
+       ;; `load-theme's NO-ENABLE argument (#420, #325).
+       ,@(eval childtheme-sexp)
+       ,@solarized-definition)))
 
 (defmacro solarized-with-color-variables-with-palette (variant theme-name core-palette &optional childtheme-sexp)
   "Create a VARIANT of the theme named THEME-NAME with CORE-PALETTE.


### PR DESCRIPTION
The child-theme cluster (#352, #420, #325) all trace back to one line: we bound `custom--inhibit-theme-enable` to nil around the face definitions so that a child theme could override the base faces. That worked, but it also forced every face to apply the moment the theme was *loaded*, so `load-theme`'s NO-ENABLE argument was effectively ignored and merely loading the theme had side effects.

Turns out `custom-theme-set-faces` keeps the *first* spec it sees for a given face. So instead of the inhibit hack, this emits the child theme's faces before the base definition - the child wins by ordering. That lets `custom--inhibit-theme-enable` keep the binding `load-theme` gives it, so faces are only recorded until the theme is actually enabled.

Verified that the recorded face specs are byte-for-byte identical to before (child overrides like wombat-dark's mode-line still win), that a no-enable load no longer mutates face state, and that deferred `enable-theme` works.

Closes #420, closes #325, closes #352.