### PR TITLE
fix terminal history autosuggestions

### DIFF
--- a/solarized-faces.el
+++ b/solarized-faces.el
@@ -95,7 +95,7 @@
      `(ansi-color-blue ((,class (:foreground ,blue :background ,blue))))
      `(ansi-color-magenta ((,class (:foreground ,magenta :background ,magenta))))
      `(ansi-color-cyan ((,class (:foreground ,cyan :background ,cyan))))
-     `(ansi-color-bright-black ((,class (:foreground ,base0 :background ,base0))))
+     `(ansi-color-bright-black ((,class (:foreground ,base01 :background ,base01))))
      `(ansi-color-bright-red ((,class (:foreground ,red-l :background ,red-l))))
      `(ansi-color-bright-green ((,class (:foreground ,green-l :background ,green-l))))
      `(ansi-color-bright-yellow ((,class (:foreground ,yellow-l :background ,yellow-l))))
@@ -1975,6 +1975,7 @@
 ;;;;; term
      `(term ((t ( :background ,base03 :foreground ,base0))))
      `(term-color-black ((t (:foreground ,base02 :background ,base02))))
+     `(term-color-bright-black ((t (:foreground ,base01 :background ,base01))))
      `(term-color-red ((t (:foreground ,red :background ,red))))
      `(term-color-green ((t (:foreground ,green :background ,green))))
      `(term-color-yellow ((t (:foreground ,yellow :background ,yellow))))


### PR DESCRIPTION
[Autosuggestions](https://github.com/zsh-users/zsh-history-substring-search) were indistinguishable from plain text.

Before:
<img width="360" height="37" alt="Screenshot 2026-07-05 at 01 06 30" src="https://github.com/user-attachments/assets/03465075-1e26-4844-9416-acf4ce473e94" />
After:
<img width="355" height="37" alt="Screenshot 2026-07-05 at 01 24 24" src="https://github.com/user-attachments/assets/706ca20e-6a5c-4c25-8e69-c99818bfe846" />
